### PR TITLE
feat(web-shell): notification + clipboard cross-shell parity (Phase 3c.6)

### DIFF
--- a/desktop-app-vue/src/main/index.js
+++ b/desktop-app-vue/src/main/index.js
@@ -879,6 +879,10 @@ class ChainlessChainApp {
         // (cursor / tombstones / status). Null pre-init is safe; handlers
         // return error envelope.
         database: this.database ?? null,
+        // Phase 3c.6 — RAGManager so knowledge.add-item (web-shell clipboard
+        // import) keeps the knowledge index in sync the same way the V5/V6
+        // db:add-knowledge-item IPC handler does. Best-effort; null is safe.
+        ragManager: this.ragManager ?? null,
         mainWindow: this.mainWindow,
         // Phase 1.6 — lazy getter so `shell.switch` topic can persist the
         // ui.useWebShellExperimental opt-out from inside web-panel.

--- a/desktop-app-vue/src/main/web-shell/__tests__/knowledge-handlers.test.js
+++ b/desktop-app-vue/src/main/web-shell/__tests__/knowledge-handlers.test.js
@@ -1,0 +1,151 @@
+/**
+ * knowledge.* WS handler 单元测试 — Phase 3c.6 web-shell parity
+ *
+ * Handler 直接 delegate 到 database.addKnowledgeItem(item)，所以 mock 一个
+ * fake DatabaseManager 就够了。RAG 索引同步是 best-effort，单测里覆盖
+ * "没有 ragManager"、"ragManager 抛错"、"ragManager 成功" 三种路径。
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const {
+  createKnowledgeHandlers,
+  createKnowledgeAddItemHandler,
+} = require("../handlers/knowledge-handlers");
+
+function makeDb({ throwOnAdd = false } = {}) {
+  return {
+    addKnowledgeItem: vi.fn((item) => {
+      if (throwOnAdd) {
+        throw new Error("constraint failed");
+      }
+      return { id: "uuid-1", ...item };
+    }),
+  };
+}
+
+// ── factory ─────────────────────────────────────────────────────
+
+describe("knowledge-handlers · factory", () => {
+  it("returns the knowledge.add-item topic", () => {
+    const handlers = createKnowledgeHandlers({ database: makeDb() });
+    expect(Object.keys(handlers)).toEqual(["knowledge.add-item"]);
+  });
+
+  it("works with no args (database defaults to null)", () => {
+    const handlers = createKnowledgeHandlers();
+    expect(typeof handlers["knowledge.add-item"]).toBe("function");
+  });
+});
+
+// ── knowledge.add-item ──────────────────────────────────────────
+
+describe("knowledge.add-item", () => {
+  it("delegates to database.addKnowledgeItem and returns the new item", async () => {
+    const db = makeDb();
+    const handler = createKnowledgeAddItemHandler({ database: db });
+    const result = await handler({
+      item: {
+        title: "Clip",
+        content: "hello",
+        tags: ["a", "b"],
+      },
+    });
+    expect(result).toEqual({
+      success: true,
+      item: {
+        id: "uuid-1",
+        title: "Clip",
+        content: "hello",
+        tags: ["a", "b"],
+        type: "note",
+      },
+    });
+    expect(db.addKnowledgeItem).toHaveBeenCalledWith({
+      title: "Clip",
+      type: "note",
+      content: "hello",
+      tags: ["a", "b"],
+    });
+  });
+
+  it("accepts a flat frame as item (no .item wrapper) for ergonomics", async () => {
+    const db = makeDb();
+    const handler = createKnowledgeAddItemHandler({ database: db });
+    const result = await handler({
+      title: "Flat",
+      content: "x",
+    });
+    expect(result.success).toBe(true);
+    expect(result.item.title).toBe("Flat");
+  });
+
+  it("defaults type to 'note' and tags to []", async () => {
+    const db = makeDb();
+    const handler = createKnowledgeAddItemHandler({ database: db });
+    await handler({ item: { title: "t", content: "c" } });
+    expect(db.addKnowledgeItem).toHaveBeenCalledWith({
+      title: "t",
+      type: "note",
+      content: "c",
+      tags: [],
+    });
+  });
+
+  it("returns 数据库未初始化 when database is null", async () => {
+    const handler = createKnowledgeAddItemHandler({ database: null });
+    const result = await handler({ item: { title: "t", content: "c" } });
+    expect(result).toEqual({ success: false, error: "数据库未初始化" });
+  });
+
+  it("returns 缺少 title when title is empty", async () => {
+    const handler = createKnowledgeAddItemHandler({ database: makeDb() });
+    const result = await handler({ item: { title: "  ", content: "c" } });
+    expect(result).toEqual({ success: false, error: "缺少 title" });
+  });
+
+  it("returns 缺少 content when content is not a string", async () => {
+    const handler = createKnowledgeAddItemHandler({ database: makeDb() });
+    const result = await handler({ item: { title: "t", content: 42 } });
+    expect(result).toEqual({ success: false, error: "缺少 content" });
+  });
+
+  it("returns 缺少 item when frame has no item-shaped fields", async () => {
+    const handler = createKnowledgeAddItemHandler({ database: makeDb() });
+    const result = await handler(null);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/缺少/);
+  });
+
+  it("captures database errors into envelope", async () => {
+    const handler = createKnowledgeAddItemHandler({
+      database: makeDb({ throwOnAdd: true }),
+    });
+    const result = await handler({ item: { title: "t", content: "c" } });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/constraint failed/);
+  });
+
+  it("calls ragManager.addToIndex on success when provided", async () => {
+    const db = makeDb();
+    const ragManager = { addToIndex: vi.fn().mockResolvedValue(true) };
+    const handler = createKnowledgeAddItemHandler({ database: db, ragManager });
+    await handler({ item: { title: "t", content: "c" } });
+    expect(ragManager.addToIndex).toHaveBeenCalled();
+  });
+
+  it("swallows ragManager errors (best-effort) and still returns success", async () => {
+    const db = makeDb();
+    const ragManager = {
+      addToIndex: vi.fn().mockRejectedValue(new Error("rag down")),
+    };
+    const handler = createKnowledgeAddItemHandler({ database: db, ragManager });
+    const result = await handler({ item: { title: "t", content: "c" } });
+    expect(result.success).toBe(true);
+    expect(result.item).not.toBeNull();
+  });
+});

--- a/desktop-app-vue/src/main/web-shell/__tests__/notification-handlers.test.js
+++ b/desktop-app-vue/src/main/web-shell/__tests__/notification-handlers.test.js
@@ -1,0 +1,287 @@
+/**
+ * notification.* WS handler 单元测试 — Phase 3c.6 web-shell parity
+ *
+ * 与 sync-status-handlers.test 同款 SQL-route fake-db pattern：handler 直接
+ * 写 prepare(...).run/get/all，所以 mock 一个能按 SQL 字符串路由的 db。
+ *
+ * Notification.send-desktop 注入 `notificationModule` 替身，避免 require
+ * Electron。
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const {
+  createNotificationHandlers,
+  createNotificationListHandler,
+  createNotificationUnreadCountHandler,
+  createNotificationMarkReadHandler,
+  createNotificationMarkAllReadHandler,
+  createNotificationSendDesktopHandler,
+} = require("../handlers/notification-handlers");
+
+// ── helpers ─────────────────────────────────────────────────────
+
+function makeFakeDb(rows = [], { throwOn } = {}) {
+  let unread = rows.filter((r) => !r.is_read).length;
+  const allRows = rows.slice();
+  return {
+    db: {
+      prepare(sql) {
+        if (throwOn && throwOn.test(sql)) {
+          return {
+            all: () => {
+              throw new Error("simulated SQL failure");
+            },
+            get: () => {
+              throw new Error("simulated SQL failure");
+            },
+            run: () => {
+              throw new Error("simulated SQL failure");
+            },
+          };
+        }
+        if (/^SELECT \* FROM notifications/i.test(sql)) {
+          return {
+            all: (...args) => {
+              if (sql.includes("WHERE is_read = ?")) {
+                const filter = args[0] === 1;
+                return allRows.filter((r) => Boolean(r.is_read) === filter);
+              }
+              return allRows;
+            },
+          };
+        }
+        if (/SELECT COUNT\(\*\) as count FROM notifications/i.test(sql)) {
+          return { get: () => ({ count: unread }) };
+        }
+        if (/UPDATE notifications SET is_read = 1 WHERE id = \?/i.test(sql)) {
+          return {
+            run: (id) => {
+              const row = allRows.find((r) => r.id === id);
+              if (row && !row.is_read) {
+                row.is_read = 1;
+                unread = Math.max(0, unread - 1);
+              }
+            },
+          };
+        }
+        if (/UPDATE notifications SET is_read = 1\s*$/i.test(sql)) {
+          return {
+            run: () => {
+              for (const r of allRows) {
+                r.is_read = 1;
+              }
+              unread = 0;
+            },
+          };
+        }
+        return { all: () => [], get: () => null, run: () => {} };
+      },
+    },
+    saveToFile: vi.fn(),
+  };
+}
+
+// ── factory ─────────────────────────────────────────────────────
+
+describe("notification-handlers · factory", () => {
+  it("returns exactly 5 topics", () => {
+    const handlers = createNotificationHandlers({ database: makeFakeDb() });
+    expect(Object.keys(handlers).sort()).toEqual([
+      "notification.list",
+      "notification.mark-all-read",
+      "notification.mark-read",
+      "notification.send-desktop",
+      "notification.unread-count",
+    ]);
+  });
+
+  it("works with no args (database defaults to null)", () => {
+    const handlers = createNotificationHandlers();
+    expect(Object.keys(handlers)).toHaveLength(5);
+    for (const fn of Object.values(handlers)) {
+      expect(typeof fn).toBe("function");
+    }
+  });
+});
+
+// ── notification.list ───────────────────────────────────────────
+
+describe("notification.list", () => {
+  it("returns rows from notifications table", async () => {
+    const handler = createNotificationListHandler({
+      database: makeFakeDb([
+        { id: 1, title: "a", is_read: 0, created_at: 1 },
+        { id: 2, title: "b", is_read: 1, created_at: 2 },
+      ]),
+    });
+    const result = await handler({});
+    expect(result.success).toBe(true);
+    expect(result.notifications).toHaveLength(2);
+  });
+
+  it("filters by isRead = true (only read rows)", async () => {
+    const handler = createNotificationListHandler({
+      database: makeFakeDb([
+        { id: 1, title: "a", is_read: 0, created_at: 1 },
+        { id: 2, title: "b", is_read: 1, created_at: 2 },
+      ]),
+    });
+    const result = await handler({ isRead: true });
+    expect(result.notifications).toEqual([
+      { id: 2, title: "b", is_read: 1, created_at: 2 },
+    ]);
+  });
+
+  it("returns empty list when database is null (no error)", async () => {
+    const handler = createNotificationListHandler({ database: null });
+    const result = await handler({});
+    expect(result).toEqual({ success: true, notifications: [] });
+  });
+
+  it("returns error envelope on SQL failure", async () => {
+    const handler = createNotificationListHandler({
+      database: makeFakeDb([], { throwOn: /SELECT \* FROM/i }),
+    });
+    const result = await handler({});
+    expect(result.success).toBe(false);
+    expect(result.notifications).toEqual([]);
+    expect(result.error).toMatch(/simulated/);
+  });
+});
+
+// ── notification.unread-count ───────────────────────────────────
+
+describe("notification.unread-count", () => {
+  it("returns count from COUNT(*) query", async () => {
+    const handler = createNotificationUnreadCountHandler({
+      database: makeFakeDb([
+        { id: 1, is_read: 0 },
+        { id: 2, is_read: 0 },
+        { id: 3, is_read: 1 },
+      ]),
+    });
+    const result = await handler();
+    expect(result).toEqual({ success: true, count: 2 });
+  });
+
+  it("returns 0 when database is null", async () => {
+    const handler = createNotificationUnreadCountHandler({ database: null });
+    const result = await handler();
+    expect(result).toEqual({ success: true, count: 0 });
+  });
+});
+
+// ── notification.mark-read ──────────────────────────────────────
+
+describe("notification.mark-read", () => {
+  it("marks a single row as read and persists", async () => {
+    const db = makeFakeDb([
+      { id: 1, is_read: 0 },
+      { id: 2, is_read: 0 },
+    ]);
+    const handler = createNotificationMarkReadHandler({ database: db });
+    const result = await handler({ id: 1 });
+    expect(result).toEqual({ success: true });
+    expect(db.saveToFile).toHaveBeenCalled();
+  });
+
+  it("rejects when id is missing", async () => {
+    const handler = createNotificationMarkReadHandler({
+      database: makeFakeDb(),
+    });
+    const result = await handler({});
+    expect(result).toEqual({ success: false, error: "缺少 id" });
+  });
+
+  it("returns 数据库未初始化 when database is null", async () => {
+    const handler = createNotificationMarkReadHandler({ database: null });
+    const result = await handler({ id: 1 });
+    expect(result).toEqual({ success: false, error: "数据库未初始化" });
+  });
+});
+
+// ── notification.mark-all-read ──────────────────────────────────
+
+describe("notification.mark-all-read", () => {
+  it("marks all rows as read", async () => {
+    const db = makeFakeDb([
+      { id: 1, is_read: 0 },
+      { id: 2, is_read: 0 },
+    ]);
+    const handler = createNotificationMarkAllReadHandler({ database: db });
+    const result = await handler();
+    expect(result).toEqual({ success: true });
+    expect(db.saveToFile).toHaveBeenCalled();
+  });
+
+  it("returns 数据库未初始化 when database is null", async () => {
+    const handler = createNotificationMarkAllReadHandler({ database: null });
+    const result = await handler();
+    expect(result).toEqual({ success: false, error: "数据库未初始化" });
+  });
+});
+
+// ── notification.send-desktop ───────────────────────────────────
+
+describe("notification.send-desktop", () => {
+  function makeNotificationStub({
+    supported = true,
+    throwOnShow = false,
+  } = {}) {
+    const calls = [];
+    function FakeNotification(opts) {
+      calls.push(opts);
+      this.show = () => {
+        if (throwOnShow) {
+          throw new Error("show failed");
+        }
+      };
+    }
+    FakeNotification.isSupported = () => supported;
+    FakeNotification.calls = calls;
+    return FakeNotification;
+  }
+
+  it("constructs Notification with title + body and shows it", async () => {
+    const stub = makeNotificationStub();
+    const handler = createNotificationSendDesktopHandler({
+      notificationModule: stub,
+      iconPath: "/fake/icon.png",
+    });
+    const result = await handler({ title: "Hi", body: "There" });
+    expect(result).toEqual({ success: true });
+    expect(stub.calls).toEqual([
+      { title: "Hi", body: "There", icon: "/fake/icon.png" },
+    ]);
+  });
+
+  it("rejects when title is missing", async () => {
+    const handler = createNotificationSendDesktopHandler({
+      notificationModule: makeNotificationStub(),
+    });
+    const result = await handler({ body: "no title" });
+    expect(result).toEqual({ success: false, error: "缺少 title" });
+  });
+
+  it("returns 桌面通知不可用 when isSupported returns false", async () => {
+    const handler = createNotificationSendDesktopHandler({
+      notificationModule: makeNotificationStub({ supported: false }),
+    });
+    const result = await handler({ title: "x" });
+    expect(result).toEqual({ success: false, error: "桌面通知不可用" });
+  });
+
+  it("captures show() failures into envelope error", async () => {
+    const handler = createNotificationSendDesktopHandler({
+      notificationModule: makeNotificationStub({ throwOnShow: true }),
+    });
+    const result = await handler({ title: "x" });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/show failed/);
+  });
+});

--- a/desktop-app-vue/src/main/web-shell/handlers/knowledge-handlers.js
+++ b/desktop-app-vue/src/main/web-shell/handlers/knowledge-handlers.js
@@ -1,0 +1,75 @@
+/**
+ * `knowledge.*` WS handlers — Phase 3c.6 web-shell parity (2026-05-06).
+ *
+ * 暴露 1 个 topic 给 web-panel，对齐 V5/V6 桌面壳 `db:add-knowledge-item`：
+ *   knowledge.add-item       → database.addKnowledgeItem({title,type,content,tags})
+ *
+ * 用途：剪贴板导入 / 截图识别 / 任意"快速保存到知识库"路径。Notes.vue 的
+ *   常规 CRUD 走 `note add` CLI（没有锁冲突，因为 cli 子进程 spawn 后立即
+ *   退出），但剪贴板导入在 V5/V6 直接调 IPC 写主进程 db，所以 web-shell
+ *   也走同样的 in-process 写法（避免 spawn 子进程争 SQLite 锁）。
+ *
+ * RAG 同步：与 desktop IPC 不同，本 handler 暂不接 ragManager.addToIndex —
+ *   web-shell 在 Phase 3c.6 不需要立即索引，knowledge.add-item 只负责 row
+ *   写入。如果将来 web-panel 需要同步索引，从 options.ragManager 注入。
+ *
+ * database / item 结构：
+ *   item.title    string  必需
+ *   item.content  string  必需
+ *   item.type     string  默认 "note"
+ *   item.tags     array   可选
+ */
+
+function createKnowledgeAddItemHandler({ database, ragManager } = {}) {
+  return async function knowledgeAddItemHandler(frame = {}) {
+    if (!database || typeof database.addKnowledgeItem !== "function") {
+      return { success: false, error: "数据库未初始化" };
+    }
+    const item = frame?.item ?? frame;
+    if (!item || typeof item !== "object") {
+      return { success: false, error: "缺少 item" };
+    }
+    if (typeof item.title !== "string" || !item.title.trim()) {
+      return { success: false, error: "缺少 title" };
+    }
+    if (typeof item.content !== "string") {
+      return { success: false, error: "缺少 content" };
+    }
+    try {
+      const newItem = database.addKnowledgeItem({
+        title: item.title,
+        type: item.type || "note",
+        content: item.content,
+        tags: Array.isArray(item.tags) ? item.tags : [],
+      });
+      if (
+        newItem &&
+        ragManager &&
+        typeof ragManager.addToIndex === "function"
+      ) {
+        try {
+          await ragManager.addToIndex(newItem);
+        } catch {
+          /* index sync is best-effort; row is already persisted */
+        }
+      }
+      return { success: true, item: newItem || null };
+    } catch (err) {
+      return { success: false, error: err?.message || String(err) };
+    }
+  };
+}
+
+function createKnowledgeHandlers({ database, ragManager } = {}) {
+  return {
+    "knowledge.add-item": createKnowledgeAddItemHandler({
+      database,
+      ragManager,
+    }),
+  };
+}
+
+module.exports = {
+  createKnowledgeHandlers,
+  createKnowledgeAddItemHandler,
+};

--- a/desktop-app-vue/src/main/web-shell/handlers/notification-handlers.js
+++ b/desktop-app-vue/src/main/web-shell/handlers/notification-handlers.js
@@ -1,0 +1,186 @@
+/**
+ * `notification.*` WS handlers — Phase 3c.6 web-shell parity (2026-05-06).
+ *
+ * 暴露 5 个 topic 给 web-panel，对齐 V5/V6 桌面壳 `notification:*` IPC：
+ *   notification.list              → SELECT * FROM notifications LIMIT/OFFSET
+ *   notification.unread-count      → SELECT COUNT(*) WHERE is_read = 0
+ *   notification.mark-read         → UPDATE … WHERE id = ?
+ *   notification.mark-all-read     → UPDATE … (no WHERE)
+ *   notification.send-desktop      → new Notification({title, body}).show()
+ *
+ * 为什么不复用 IPC handler：
+ *   ipcMain.handle 绑死 Electron IPC 通道，web-shell 走 WS dispatcher。直接
+ *   重写 SQL（同 sync-status-handlers）零依赖、最便宜。
+ *
+ * database 可能为 null（pre-bootstrap），各 handler 返回结构化错误而不抛，
+ * 避免 ws-cli-loader 把 dispatcher trip 掉。
+ */
+
+const path = require("path");
+
+function loadNotificationModule(options) {
+  if (options.notificationModule) {
+    return options.notificationModule;
+  }
+  // Lazy-require so unit tests don't pull in Electron.
+  return require("electron").Notification;
+}
+
+function _getDb(database) {
+  if (!database || !database.db) {
+    return null;
+  }
+  return database.db;
+}
+
+function _persist(database) {
+  // sql.js 后备需要 saveToFile() 落盘；SQLCipher 适配器自动持久化但调用无害。
+  if (database && typeof database.saveToFile === "function") {
+    try {
+      database.saveToFile();
+    } catch {
+      /* ignore — write already landed in WAL */
+    }
+  }
+}
+
+function createNotificationListHandler({ database }) {
+  return async function notificationListHandler(frame = {}) {
+    const db = _getDb(database);
+    if (!db) {
+      return { success: true, notifications: [] };
+    }
+    try {
+      const limit = Number.isFinite(Number(frame?.limit))
+        ? Math.max(1, Math.min(500, Math.floor(Number(frame.limit))))
+        : 50;
+      const offset = Number.isFinite(Number(frame?.offset))
+        ? Math.max(0, Math.floor(Number(frame.offset)))
+        : 0;
+      const isReadFilter =
+        typeof frame?.isRead === "boolean" ? frame.isRead : undefined;
+
+      let query = "SELECT * FROM notifications";
+      const params = [];
+      if (isReadFilter !== undefined) {
+        query += " WHERE is_read = ?";
+        params.push(isReadFilter ? 1 : 0);
+      }
+      query += " ORDER BY created_at DESC LIMIT ? OFFSET ?";
+      params.push(limit, offset);
+
+      const notifications = db.prepare(query).all(...params);
+      return { success: true, notifications: notifications || [] };
+    } catch (err) {
+      return {
+        success: false,
+        notifications: [],
+        error: err?.message || String(err),
+      };
+    }
+  };
+}
+
+function createNotificationUnreadCountHandler({ database }) {
+  return async function notificationUnreadCountHandler() {
+    const db = _getDb(database);
+    if (!db) {
+      return { success: true, count: 0 };
+    }
+    try {
+      const row = db
+        .prepare(
+          "SELECT COUNT(*) as count FROM notifications WHERE is_read = 0",
+        )
+        .get();
+      return { success: true, count: row?.count ?? 0 };
+    } catch (err) {
+      return { success: false, count: 0, error: err?.message || String(err) };
+    }
+  };
+}
+
+function createNotificationMarkReadHandler({ database }) {
+  return async function notificationMarkReadHandler(frame = {}) {
+    const db = _getDb(database);
+    if (!db) {
+      return { success: false, error: "数据库未初始化" };
+    }
+    const id = frame?.id;
+    if (id === undefined || id === null || id === "") {
+      return { success: false, error: "缺少 id" };
+    }
+    try {
+      db.prepare("UPDATE notifications SET is_read = 1 WHERE id = ?").run(id);
+      _persist(database);
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: err?.message || String(err) };
+    }
+  };
+}
+
+function createNotificationMarkAllReadHandler({ database }) {
+  return async function notificationMarkAllReadHandler() {
+    const db = _getDb(database);
+    if (!db) {
+      return { success: false, error: "数据库未初始化" };
+    }
+    try {
+      db.prepare("UPDATE notifications SET is_read = 1").run();
+      _persist(database);
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: err?.message || String(err) };
+    }
+  };
+}
+
+function createNotificationSendDesktopHandler(options = {}) {
+  return async function notificationSendDesktopHandler(frame = {}) {
+    const title =
+      typeof frame?.title === "string" && frame.title.trim()
+        ? frame.title
+        : null;
+    if (!title) {
+      return { success: false, error: "缺少 title" };
+    }
+    const body = typeof frame?.body === "string" ? frame.body : "";
+    try {
+      const Notification = loadNotificationModule(options);
+      if (!Notification || !Notification.isSupported?.()) {
+        return { success: false, error: "桌面通知不可用" };
+      }
+      const iconPath =
+        options.iconPath || path.join(__dirname, "../../../resources/icon.png");
+      const n = new Notification({ title, body, icon: iconPath });
+      n.show();
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: err?.message || String(err) };
+    }
+  };
+}
+
+function createNotificationHandlers({ database, ...rest } = {}) {
+  return {
+    "notification.list": createNotificationListHandler({ database }),
+    "notification.unread-count": createNotificationUnreadCountHandler({
+      database,
+    }),
+    "notification.mark-read": createNotificationMarkReadHandler({ database }),
+    "notification.mark-all-read": createNotificationMarkAllReadHandler({
+      database,
+    }),
+    "notification.send-desktop": createNotificationSendDesktopHandler(rest),
+  };
+}
+
+module.exports = {
+  createNotificationHandlers,
+  createNotificationListHandler,
+  createNotificationUnreadCountHandler,
+  createNotificationMarkReadHandler,
+  createNotificationMarkAllReadHandler,
+  createNotificationSendDesktopHandler,
+};

--- a/desktop-app-vue/src/main/web-shell/web-shell-bootstrap.js
+++ b/desktop-app-vue/src/main/web-shell/web-shell-bootstrap.js
@@ -47,6 +47,10 @@ const { createShellSwitchHandler } = require("./handlers/shell-switch-handler");
 const { createSyncWebDAVHandlers } = require("./handlers/sync-webdav-handlers");
 const { createSyncStatusHandlers } = require("./handlers/sync-status-handlers");
 const { createGitConfigHandlers } = require("./handlers/git-config-handlers");
+const {
+  createNotificationHandlers,
+} = require("./handlers/notification-handlers");
+const { createKnowledgeHandlers } = require("./handlers/knowledge-handlers");
 
 /** CLI flag / env var that opts in to the web-shell entry point. */
 const WEB_SHELL_FLAG = "--web-shell";
@@ -69,6 +73,15 @@ const NO_WEB_SHELL_FLAG = "--no-web-shell";
  * @property {object | null} [llmManager]    LLMManager singleton (or null when
  *                                            LLM hasn't initialised yet). Drives
  *                                            the streaming `llm.chat` topic.
+ * @property {object | null} [database]      DatabaseManager singleton. Drives
+ *                                            sync.* / sync.webdav.* /
+ *                                            notification.* / knowledge.*
+ *                                            topics.
+ * @property {object | null} [ragManager]    RAG manager singleton. When non-null,
+ *                                            knowledge.add-item also indexes the
+ *                                            new row (best-effort, mirrors the
+ *                                            V5/V6 db:add-knowledge-item IPC
+ *                                            handler).
  * @property {Electron.BrowserWindow | null} [mainWindow]
  *                                            Parent window for native dialogs. Required
  *                                            for fs.openDialog / fs.saveDialog handlers.
@@ -165,6 +178,15 @@ async function startWebShell(options = {}) {
     // Phase 3c.5 — git.config-* topics. 复用 git-config.json 单例（getGitConfig），
     // web-panel 用户也能配 Git 仓库，不必切回 V5/V6 桌面 shell。
     ...createGitConfigHandlers(),
+    // Phase 3c.6 — notification.* + knowledge.* WS topics. V5/V6 通过
+    // ipcMain.handle('notification:*' / 'db:add-knowledge-item') 落主进程
+    // SQLite，web-panel 之前没有对等入口（默认壳用户看不见 / 用不上）。
+    // database 可能为 null（pre-bootstrap）— handlers 内部各自做 null 检查。
+    ...createNotificationHandlers({ database: options.database ?? null }),
+    ...createKnowledgeHandlers({
+      database: options.database ?? null,
+      ragManager: options.ragManager ?? null,
+    }),
     // Phase 1.6 — symmetric shell switch from web-panel back to V5/V6.
     // Only registered when getAppConfig is provided (it requires the
     // AppConfigManager singleton to persist the opt-out).

--- a/packages/web-panel/src/components/AppLayout.vue
+++ b/packages/web-panel/src/components/AppLayout.vue
@@ -247,6 +247,12 @@
             </button>
           </a-tooltip>
 
+          <!-- Notification bell — only meaningful in the embedded web-shell
+               where notification.* WS topics are registered. In pure-browser
+               mode the composable returns empty / no-op shapes, so the badge
+               just shows 0 and the drawer is empty. -->
+          <NotificationBell v-if="shellMode.isEmbedded" />
+
           <span class="version-tag">{{ PRODUCT_VERSION }}</span>
           <!-- Phase 1.6 symmetric switch: only inside the embedded
                desktop shell does this make sense (no-op in `cc serve`
@@ -303,6 +309,7 @@ import logoSrc from '../assets/logo.png'
 import { useShellMode } from '../composables/useShellMode.js'
 import { useI18n } from 'vue-i18n'
 import { useLocale } from '../plugins/i18n.js'
+import NotificationBell from './NotificationBell.vue'
 
 const router  = useRouter()
 const route   = useRoute()

--- a/packages/web-panel/src/components/ClipboardImportDialog.vue
+++ b/packages/web-panel/src/components/ClipboardImportDialog.vue
@@ -1,0 +1,143 @@
+<template>
+  <a-modal
+    v-model:open="open"
+    title="剪贴板导入"
+    :width="640"
+    :ok-text="loading ? '保存中…' : '保存到知识库'"
+    cancel-text="取消"
+    :ok-button-props="{ loading, disabled: !formState.content.trim() }"
+    @ok="handleSave"
+    @cancel="handleCancel"
+  >
+    <div v-if="readError" style="margin-bottom: 16px;">
+      <a-alert
+        type="warning"
+        show-icon
+        :message="readError"
+        description="请确认浏览器/系统已授予剪贴板读取权限，或手动粘贴到下方输入框。"
+      />
+    </div>
+
+    <a-form layout="vertical" :model="formState">
+      <a-form-item label="标题">
+        <a-input
+          v-model:value="formState.title"
+          placeholder="导入条目的标题"
+          allow-clear
+        />
+      </a-form-item>
+
+      <a-form-item label="内容">
+        <a-textarea
+          v-model:value="formState.content"
+          placeholder="粘贴或编辑要保存的内容…"
+          :auto-size="{ minRows: 10, maxRows: 20 }"
+          show-count
+        />
+      </a-form-item>
+
+      <a-form-item label="标签（逗号分隔，可选）">
+        <a-input
+          v-model:value="formState.tagsRaw"
+          placeholder="例如：素材, 链接"
+          allow-clear
+        />
+      </a-form-item>
+    </a-form>
+  </a-modal>
+</template>
+
+<script setup>
+import { ref, reactive, computed, watch } from 'vue'
+import { message } from 'ant-design-vue'
+import { useKnowledge } from '../composables/useKnowledge.js'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+})
+const emit = defineEmits(['update:modelValue', 'saved'])
+
+const knowledge = useKnowledge()
+
+const open = computed({
+  get: () => props.modelValue,
+  set: (val) => emit('update:modelValue', val),
+})
+
+const loading = ref(false)
+const readError = ref('')
+
+const formState = reactive({
+  title: '',
+  content: '',
+  tagsRaw: '',
+})
+
+const defaultTitle = () => `剪贴板导入 - ${new Date().toLocaleString()}`
+
+function resetForm() {
+  formState.title = defaultTitle()
+  formState.content = ''
+  formState.tagsRaw = ''
+  readError.value = ''
+}
+
+async function readClipboard() {
+  readError.value = ''
+  if (!navigator.clipboard?.readText) {
+    readError.value = '当前环境不支持剪贴板读取 API'
+    return
+  }
+  try {
+    const text = await navigator.clipboard.readText()
+    formState.content = text || ''
+    if (!text) {
+      readError.value = '剪贴板为空'
+    }
+  } catch (err) {
+    readError.value = '读取剪贴板失败：' + (err?.message || String(err))
+  }
+}
+
+watch(
+  () => props.modelValue,
+  async (val) => {
+    if (val) {
+      resetForm()
+      await readClipboard()
+    }
+  },
+  { immediate: true },
+)
+
+async function handleSave() {
+  if (!formState.content.trim()) {
+    message.warning('内容为空，无法保存')
+    return
+  }
+  loading.value = true
+  try {
+    const tags = formState.tagsRaw
+      .split(/[,，]/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+    const item = await knowledge.addItem({
+      title: formState.title.trim() || defaultTitle(),
+      content: formState.content,
+      tags,
+      type: 'note',
+    })
+    message.success('已保存到知识库')
+    emit('saved', item)
+    open.value = false
+  } catch (err) {
+    message.error('保存失败：' + (err?.message || String(err)))
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleCancel() {
+  open.value = false
+}
+</script>

--- a/packages/web-panel/src/components/NotificationBell.vue
+++ b/packages/web-panel/src/components/NotificationBell.vue
@@ -1,0 +1,225 @@
+<template>
+  <a-tooltip title="通知">
+    <a-badge :count="unreadCount" :overflow-count="99" :offset="[-4, 4]">
+      <button
+        type="button"
+        class="notif-bell-btn"
+        aria-label="通知"
+        @click="onOpen"
+      >
+        <BellOutlined />
+      </button>
+    </a-badge>
+  </a-tooltip>
+
+  <a-drawer
+    v-model:open="visible"
+    title="通知中心"
+    placement="right"
+    :width="400"
+    :body-style="{ padding: 0 }"
+  >
+    <div class="notif-toolbar">
+      <a-space>
+        <a-radio-group v-model:value="filter" size="small" button-style="solid">
+          <a-radio-button value="all">全部 ({{ notifications.length }})</a-radio-button>
+          <a-radio-button value="unread">未读 ({{ unreadCount }})</a-radio-button>
+        </a-radio-group>
+      </a-space>
+      <a-space>
+        <a-button size="small" :loading="loading" @click="refreshList">
+          <template #icon><ReloadOutlined /></template>
+        </a-button>
+        <a-button
+          size="small"
+          :disabled="unreadCount === 0"
+          @click="onMarkAllRead"
+        >
+          全部已读
+        </a-button>
+      </a-space>
+    </div>
+
+    <div class="notif-body">
+      <a-empty
+        v-if="!loading && filtered.length === 0"
+        description="暂无通知"
+        :image="Empty.PRESENTED_IMAGE_SIMPLE"
+        style="padding: 60px 0;"
+      />
+      <a-spin v-else-if="loading" style="display: block; padding: 60px;" />
+      <ul v-else class="notif-list">
+        <li
+          v-for="n in filtered"
+          :key="n.id"
+          class="notif-item"
+          :class="{ unread: !n.is_read }"
+          @click="onItemClick(n)"
+        >
+          <div class="notif-row">
+            <div class="notif-title">{{ n.title || n.message || '(无标题)' }}</div>
+            <span class="notif-time">{{ formatTime(n.created_at) }}</span>
+          </div>
+          <div v-if="n.message && n.title" class="notif-message">
+            {{ n.message }}
+          </div>
+        </li>
+      </ul>
+    </div>
+  </a-drawer>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { Empty } from 'ant-design-vue'
+import { BellOutlined, ReloadOutlined } from '@ant-design/icons-vue'
+import { useNotifications } from '../composables/useNotifications.js'
+import { useShellMode } from '../composables/useShellMode.js'
+
+const visible = ref(false)
+const filter = ref('all')
+const loading = ref(false)
+
+const { notifications, unreadCount, refresh, markRead, markAllRead } =
+  useNotifications()
+
+const filtered = computed(() => {
+  if (filter.value === 'unread') {
+    return notifications.value.filter((n) => !n.is_read)
+  }
+  return notifications.value
+})
+
+async function refreshList() {
+  if (!useShellMode().isEmbedded) {
+    return
+  }
+  loading.value = true
+  try {
+    await refresh({ limit: 100 })
+  } catch {
+    /* surfacing in-drawer would dwarf the bell — silent skip */
+  } finally {
+    loading.value = false
+  }
+}
+
+async function onOpen() {
+  visible.value = true
+  await refreshList()
+}
+
+async function onItemClick(n) {
+  if (n.is_read) return
+  try {
+    await markRead(n.id)
+  } catch {
+    /* noop — counter refresh is best-effort */
+  }
+}
+
+async function onMarkAllRead() {
+  try {
+    await markAllRead()
+  } catch (err) {
+    console.warn('[NotificationBell] markAllRead failed:', err?.message || err)
+  }
+}
+
+function formatTime(ts) {
+  if (!ts) return ''
+  const n = typeof ts === 'string' ? Date.parse(ts) : Number(ts)
+  if (!Number.isFinite(n)) return String(ts)
+  const diff = Date.now() - n
+  const minute = 60_000
+  const hour = 60 * minute
+  const day = 24 * hour
+  if (diff < minute) return '刚刚'
+  if (diff < hour) return `${Math.floor(diff / minute)} 分钟前`
+  if (diff < day) return `${Math.floor(diff / hour)} 小时前`
+  return new Date(n).toLocaleDateString()
+}
+</script>
+
+<style scoped>
+.notif-bell-btn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  color: var(--text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  transition: background 0.15s, transform 0.15s;
+}
+.notif-bell-btn:hover {
+  background: var(--bg-card-hover);
+  transform: scale(1.1);
+}
+
+.notif-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-card);
+}
+
+.notif-body {
+  max-height: calc(100vh - 130px);
+  overflow-y: auto;
+}
+
+.notif-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.notif-item {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.notif-item:hover {
+  background: var(--bg-card-hover);
+}
+.notif-item.unread {
+  background: rgba(22, 119, 255, 0.08);
+}
+.notif-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.notif-title {
+  font-weight: 500;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.notif-time {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.notif-message {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+</style>

--- a/packages/web-panel/src/composables/useKnowledge.js
+++ b/packages/web-panel/src/composables/useKnowledge.js
@@ -1,0 +1,69 @@
+/**
+ * useKnowledge — web-panel composable wrapping `knowledge.*` WS topics
+ * (Phase 3c.6, 2026-05-06). Pure-browser mode falls back to the
+ * `note add "..."` CLI execute path, which works the same way Notes.vue
+ * already adds notes (no in-process db conflict because cc CLI subprocess
+ * exits immediately after writing its own row).
+ *
+ * Embedded shell (Electron) MUST go through the WS topic to avoid spawning
+ * a second cc process competing with the main process db handle.
+ *
+ * Usage:
+ *   const k = useKnowledge()
+ *   const item = await k.addItem({ title, content, tags: ['素材'], type: 'note' })
+ */
+
+import { useWsStore } from '../stores/ws.js'
+import { useShellMode } from './useShellMode.js'
+
+function _unwrap(reply) {
+  if (reply && reply.ok === false) {
+    throw new Error(reply.error || 'knowledge handler failed')
+  }
+  return reply?.result ?? reply
+}
+
+function _shellQuote(s) {
+  return String(s).replace(/(["\\])/g, '\\$1')
+}
+
+export function useKnowledge() {
+  const ws = useWsStore()
+
+  async function addItem({ title, content, tags = [], type = 'note' } = {}) {
+    if (typeof title !== 'string' || !title.trim()) {
+      throw new Error('title is required')
+    }
+    if (typeof content !== 'string') {
+      throw new Error('content is required')
+    }
+    const tagsArr = Array.isArray(tags) ? tags.filter(Boolean) : []
+
+    if (useShellMode().isEmbedded) {
+      const reply = await ws.sendRaw(
+        {
+          type: 'knowledge.add-item',
+          item: { title: title.trim(), content, tags: tagsArr, type },
+        },
+        20000,
+      )
+      const r = _unwrap(reply)
+      if (r?.success === false) {
+        throw new Error(r.error || 'knowledge.add-item failed')
+      }
+      return r?.item ?? null
+    }
+
+    // Pure-browser fallback: use the CLI execute channel that Notes.vue
+    // already relies on. Tags need a trailing -t flag with comma list.
+    let cmd = `note add "${_shellQuote(title.trim())}" -c "${_shellQuote(content)}"`
+    if (tagsArr.length) cmd += ` -t "${_shellQuote(tagsArr.join(','))}"`
+    const { output } = await ws.execute(cmd, 15000)
+    if (output && /^[\s\S]*✖|error/i.test(output)) {
+      throw new Error(output.slice(0, 200))
+    }
+    return { title: title.trim(), content, tags: tagsArr, type }
+  }
+
+  return { addItem }
+}

--- a/packages/web-panel/src/composables/useNotifications.js
+++ b/packages/web-panel/src/composables/useNotifications.js
@@ -1,0 +1,130 @@
+/**
+ * useNotifications — web-panel composable for the desktop `notifications`
+ * SQLite table, surfaced via the embedded web-shell's `notification.*` WS
+ * topics (Phase 3c.6, 2026-05-06). Mirrors the V5/V6 ipcRenderer.invoke
+ * surface (`notification:*`) so Phase 1.6 default-shell users get parity.
+ *
+ * Pattern mirrors useFs.js: branch on useShellMode().isEmbedded — outside
+ * the embedded shell (pure browser, no WS topic backing) the composable
+ * returns empty / no-op shapes so the bell badge doesn't error.
+ *
+ * Usage:
+ *   const { notifications, unreadCount, refresh, markRead, markAllRead,
+ *           sendDesktop } = useNotifications()
+ *   await refresh()                      // populates notifications + count
+ *   await markRead(123)
+ *   await markAllRead()
+ *   await sendDesktop('标题', '正文')    // toast via Electron Notification
+ */
+
+import { ref, computed } from 'vue'
+import { useWsStore } from '../stores/ws.js'
+import { useShellMode } from './useShellMode.js'
+
+const _state = {
+  notifications: ref([]),
+  unreadCount: ref(0),
+}
+
+function _unwrap(reply) {
+  if (reply && reply.ok === false) {
+    throw new Error(reply.error || 'notification handler failed')
+  }
+  return reply?.result ?? reply
+}
+
+export function useNotifications() {
+  const ws = useWsStore()
+
+  async function refresh({ limit = 50, offset = 0, isRead } = {}) {
+    if (!useShellMode().isEmbedded) {
+      _state.notifications.value = []
+      _state.unreadCount.value = 0
+      return _state.notifications.value
+    }
+    const reply = await ws.sendRaw(
+      { type: 'notification.list', limit, offset, isRead },
+      15000,
+    )
+    const r = _unwrap(reply)
+    if (r?.success === false) {
+      throw new Error(r.error || 'notification.list failed')
+    }
+    _state.notifications.value = Array.isArray(r?.notifications)
+      ? r.notifications
+      : []
+    await refreshUnreadCount()
+    return _state.notifications.value
+  }
+
+  async function refreshUnreadCount() {
+    if (!useShellMode().isEmbedded) {
+      _state.unreadCount.value = 0
+      return 0
+    }
+    const reply = await ws.sendRaw(
+      { type: 'notification.unread-count' },
+      10000,
+    )
+    const r = _unwrap(reply)
+    _state.unreadCount.value = Number(r?.count) || 0
+    return _state.unreadCount.value
+  }
+
+  async function markRead(id) {
+    if (id === undefined || id === null || id === '') {
+      throw new Error('id is required')
+    }
+    if (!useShellMode().isEmbedded) return
+    const reply = await ws.sendRaw(
+      { type: 'notification.mark-read', id },
+      10000,
+    )
+    const r = _unwrap(reply)
+    if (r?.success === false) {
+      throw new Error(r.error || 'notification.mark-read failed')
+    }
+    // Local optimistic update so the UI flips without a full refetch.
+    const target = _state.notifications.value.find((n) => n.id === id)
+    if (target) target.is_read = 1
+    await refreshUnreadCount()
+  }
+
+  async function markAllRead() {
+    if (!useShellMode().isEmbedded) return
+    const reply = await ws.sendRaw(
+      { type: 'notification.mark-all-read' },
+      10000,
+    )
+    const r = _unwrap(reply)
+    if (r?.success === false) {
+      throw new Error(r.error || 'notification.mark-all-read failed')
+    }
+    for (const n of _state.notifications.value) n.is_read = 1
+    _state.unreadCount.value = 0
+  }
+
+  async function sendDesktop(title, body = '') {
+    if (!useShellMode().isEmbedded) {
+      throw new Error('桌面通知仅在嵌入式 web-shell 中可用')
+    }
+    const reply = await ws.sendRaw(
+      { type: 'notification.send-desktop', title, body },
+      10000,
+    )
+    const r = _unwrap(reply)
+    if (r?.success === false) {
+      throw new Error(r.error || 'notification.send-desktop failed')
+    }
+  }
+
+  return {
+    notifications: computed(() => _state.notifications.value),
+    unreadCount: computed(() => _state.unreadCount.value),
+    refresh,
+    refreshUnreadCount,
+    markRead,
+    markAllRead,
+    sendDesktop,
+  }
+}

--- a/packages/web-panel/src/views/Notes.vue
+++ b/packages/web-panel/src/views/Notes.vue
@@ -10,6 +10,10 @@
           <template #icon><PlusOutlined /></template>
           新建笔记
         </a-button>
+        <a-button @click="showClipboardImport = true">
+          <template #icon><SnippetsOutlined /></template>
+          剪贴板导入
+        </a-button>
         <a-button ghost :loading="loading" @click="loadNotes">
           <template #icon><ReloadOutlined /></template>
           刷新
@@ -90,6 +94,12 @@
       </a-form>
     </a-modal>
 
+    <!-- Clipboard import modal -->
+    <ClipboardImportDialog
+      v-model="showClipboardImport"
+      @saved="onClipboardSaved"
+    />
+
     <!-- View Note Modal -->
     <a-modal
       v-model:open="showView"
@@ -115,10 +125,11 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { PlusOutlined, ReloadOutlined, FileTextOutlined, DownloadOutlined } from '@ant-design/icons-vue'
+import { PlusOutlined, ReloadOutlined, FileTextOutlined, DownloadOutlined, SnippetsOutlined } from '@ant-design/icons-vue'
 import { message } from 'ant-design-vue'
 import { useWsStore } from '../stores/ws.js'
 import { useFs } from '../composables/useFs.js'
+import ClipboardImportDialog from '../components/ClipboardImportDialog.vue'
 
 const ws = useWsStore()
 const fs = useFs()
@@ -134,8 +145,14 @@ const isSearchMode = ref(false)
 const searchQuery = ref('')
 const showAdd = ref(false)
 const showView = ref(false)
+const showClipboardImport = ref(false)
 const viewingNote = ref(null)
 const newNote = ref({ title: '', content: '', tags: '' })
+
+async function onClipboardSaved() {
+  message.success('剪贴板内容已保存到知识库')
+  await loadNotes()
+}
 
 const displayNotes = computed(() => isSearchMode.value ? searchResults.value : notes.value)
 


### PR DESCRIPTION
## Summary

桌面 V5/V6 的通知中心和剪贴板导入此前没有 web-shell 入口，Phase 1.6 默认壳用户看不见这两个功能。补 WS topic + web-panel UI 对齐。

- **5 个 `notification.*` WS topics** (`list / unread-count / mark-read / mark-all-read / send-desktop`) wrap the `notification-ipc.js` SQL surface in-process — avoids `ws.execute('cc …')` 子进程争 SQLite 锁 (same precedent as `sync-status-handlers`).
- **`knowledge.add-item` WS topic** for the clipboard import save path; optional `ragManager.addToIndex` mirrors the `db:add-knowledge-item` IPC behaviour.
- **web-panel side**: `useNotifications` + `useKnowledge` composables (sendRaw envelope pattern from `useFs.js`), `NotificationBell` drawer mounted in `AppLayout` header (gated by `useShellMode().isEmbedded`), `ClipboardImportDialog` wired into `Notes.vue` toolbar.
- **29 new vitest cases** (260/260 web-shell suite green).

截图识别 deferred — design memo captured locally (tmp-dir gate reuse + dataUrl 15 MB problem + pure-browser disable story). 全局搜索 needs a separate backend-semantics decision before porting.

## Test plan

- [x] New unit tests pass: `npx vitest run src/main/web-shell/__tests__/notification-handlers.test.js src/main/web-shell/__tests__/knowledge-handlers.test.js` → 29/29
- [x] Full web-shell suite stays green: `npx vitest run src/main/web-shell/__tests__/` → 260/260 (4 skipped are existing native-dep gated)
- [x] TypeScript type-check passes (verified by pre-push hook)
- [ ] **Manual smoke (TODO before merge)**: `npm run dev` in `desktop-app-vue`, confirm bell badge appears in web-shell header, click → drawer renders existing notifications; open Notes view, click 剪贴板导入 → dialog reads clipboard → save lands a row visible in V5/V6 desktop shell after switch.
- [ ] Verify `notification.send-desktop` actually triggers an OS notification on Windows (uses `electron.Notification`).

## Rollout notes

- `web-shell-bootstrap.js` adds 1 ragManager param to `StartWebShellOptions` JSDoc; `index.js` plumbs `this.ragManager`. Null-safe — null pre-init returns clean envelope errors.
- No CLI changes. No npm package version bumps. No deployment changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)