### PR TITLE
ci(release): drop NODE_AUTH_TOKEN — npm OIDC trusted publishing only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1294,8 +1294,6 @@ jobs:
           else
             npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: "Publish @chainlesschain/shared-logger"
         if: needs.publish-cli-precheck.outputs.already_published != 'true'
@@ -1308,8 +1306,6 @@ jobs:
           else
             npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: "Publish @chainlesschain/core-config"
         if: needs.publish-cli-precheck.outputs.already_published != 'true'
@@ -1322,8 +1318,6 @@ jobs:
           else
             npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: "Publish @chainlesschain/core-db"
         if: needs.publish-cli-precheck.outputs.already_published != 'true'
@@ -1336,8 +1330,6 @@ jobs:
           else
             npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: "Publish @chainlesschain/core-infra"
         if: needs.publish-cli-precheck.outputs.already_published != 'true'
@@ -1350,8 +1342,6 @@ jobs:
           else
             npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Confirm CLI version matches resolved version
         # No-op safety net: VERSION already comes from packages/cli/package.json
@@ -1369,8 +1359,6 @@ jobs:
         if: needs.publish-cli-precheck.outputs.already_published != 'true'
         working-directory: packages/cli
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Regenerate CHANGELOG.md after a successful release. documentation.yml's
   # auto-run on push deliberately skips changelog (it would grow by one line


### PR DESCRIPTION
## Summary

Drop the 6 `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` blocks from the `publish-cli` job in `.github/workflows/release.yml`, leaving npm OIDC trusted publishing as the only publish auth path.

The workflow has been OIDC-ready since `release.yml` was set up — `permissions.id-token: write`, `actions/setup-node@v4` with `registry-url`, and `npm publish --provenance --access public` are all in place already. This PR removes the dead-weight token fallback so the publish path becomes single-rail OIDC.

**Diff: 1 file, 12 lines removed.**

## Why now

`v5.0.3.69` and `v5.0.3.70` both failed `publish-cli` with `npm error 404 - PUT https://registry.npmjs.org/chainlesschain - Not found` on 2026-05-19. `NPM_TOKEN` had been working at 15:50 UTC (successful `chainlesschain@0.162.3` publish for v5.0.3.68) and stopped working by 21:02 UTC, ~5h later — likely token TTL boundary or silent revocation. v5.0.3.70 only published to GitHub Releases; npm registry still shows `chainlesschain@0.162.3` as latest. OIDC removes this whole class of failure: no static secret, no rotation, no silent expiry.

## ⚠️ Do NOT merge yet — prerequisite

Trusted Publisher must be configured on **all 6 packages** on npmjs.com **before** this PR merges. Otherwise the very next release will hit a hard `npm publish` 401/403 (no token, no OIDC config).

### npm UI checklist (one-time setup, ~5 min)

For each of the 6 packages below, visit the Access tab and add a Trusted Publisher with:

```
Publisher:              GitHub Actions
Organization or user:   chainlesschain
Repository:             chainlesschain
Workflow filename:      release.yml
Environment name:       (leave empty)
```

- [ ] [`chainlesschain`](https://www.npmjs.com/package/chainlesschain/access)
- [ ] [`@chainlesschain/core-env`](https://www.npmjs.com/package/@chainlesschain/core-env/access)
- [ ] [`@chainlesschain/shared-logger`](https://www.npmjs.com/package/@chainlesschain/shared-logger/access)
- [ ] [`@chainlesschain/core-config`](https://www.npmjs.com/package/@chainlesschain/core-config/access)
- [ ] [`@chainlesschain/core-db`](https://www.npmjs.com/package/@chainlesschain/core-db/access)
- [ ] [`@chainlesschain/core-infra`](https://www.npmjs.com/package/@chainlesschain/core-infra/access)

### npm account requirement

- [ ] `longfa` npm account 2FA must be **Enabled for write** (not just "for authorization"). The Trusted Publishers section in the Access tab is hidden until this is set.

## Validation before merge (recommended)

- [ ] Configure all 6 packages above (Trusted Publishers section saved on each)
- [ ] Cut **one** test release (or rerun `publish-cli --failed` on the v5.0.3.70 workflow) while this PR is still on the branch (i.e., NPM_TOKEN env still in main's release.yml). If OIDC is working, `npm publish` automatically prefers OIDC over the token — the log should show OIDC token exchange (`npm notice publish Granted token via trusted publisher` or equivalent) before the PUT
- [ ] Confirm via `npm view chainlesschain time` that the new version is now on the npm registry
- [ ] If the above ✅ — merge this PR; next release runs on OIDC only
- [ ] After merge, delete `NPM_TOKEN` GH secret: `gh secret delete NPM_TOKEN -R chainlesschain/chainlesschain` (no rotation maintenance)

## Test plan

- [ ] Pre-merge: verify Trusted Publisher config exists on all 6 packages (visit each `/access` page, confirm row shows GitHub Actions / chainlesschain / chainlesschain / release.yml)
- [ ] Pre-merge: one release with NPM_TOKEN still in env confirms OIDC takes precedence (log shows OIDC exchange + npm registry advances to new version)
- [ ] Post-merge: next release uses OIDC-only path, no `NODE_AUTH_TOKEN` env var present in `publish-cli` logs
- [ ] Post-merge: `npm view chainlesschain time` shows new version after release
- [ ] Rollback test: if OIDC config is incomplete on a package, `npm publish` for that package should fail with 401/403 (not 404). Revert this PR + restore NPM_TOKEN if needed

## What stays unchanged (already OIDC-ready)

- `permissions: id-token: write` on the `publish-cli` job (line 1269)
- `actions/setup-node@v4` with `registry-url: "https://registry.npmjs.org"` (line 1278)
- `npm publish --provenance --access public` on all 6 publish steps

## Rollback

`git revert <merge SHA>`. `NPM_TOKEN` GH secret stays in place as a hot standby until the user explicitly deletes it post-merge. npm CLI auto-falls-back to `NODE_AUTH_TOKEN` if id-token exchange fails (rare — usually only when trusted publisher config is incomplete or GH Actions OIDC service is degraded), so revert + new token is the recovery path.

## Context

- npm token previously created on 2026-03-26, suddenly stopped working ~5h after a successful publish on 2026-05-19. Token's GH secret `NPM_TOKEN` last updated 2026-03-26. `npm view chainlesschain dist-tags` confirms latest is still 0.162.3 (the version published before the token broke); 0.162.4 and 0.162.5 never reached npm registry despite being attempted twice each.
- Both `v5.0.3.69` and `v5.0.3.70` GitHub releases got stuck in `draft` state initially because `finalize-release` depends on `publish-cli` success. `v5.0.3.70` was eventually flipped to `published` manually; `v5.0.3.69` is still draft (intentionally left there — deleting a draft burns the tag for 24h per npm immutable-releases policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)