### PR TITLE
[throwaway] verify PDH staleness gates fire

### DIFF
--- a/packages/personal-data-hub/lib/index.js
+++ b/packages/personal-data-hub/lib/index.js
@@ -12,6 +12,7 @@
  * See docs/design/Personal_Data_Hub_Architecture.md.
  */
 
+// THROWAWAY: pdh-bundle-staleness-check.yml gate verification — delete me
 "use strict";
 
 const constants = require("./constants");


### PR DESCRIPTION
## Purpose

Throwaway PR to verify the 3-trap CI gate landing (commit `a7cbe12f2`) actually fires when the rules are violated.

## Setup

Single change: add a 1-line comment in `packages/personal-data-hub/lib/index.js`. No version bumps, no USR_VERSION bump.

## Expected workflow results

| Workflow | Job | Expected |
|---|---|---|
| pdh-bundle-staleness-check.yml | detect-changes | green (pdh-lib-changed=true) |
| pdh-bundle-staleness-check.yml | unit-tests | green |
| pdh-bundle-staleness-check.yml | usr-version-bump-check | 🔴 red — trap #27 USR_VERSION not bumped |
| pdh-bundle-staleness-check.yml | workspace-version-bump-check | 🔴 red — trap #28 PDH version not bumped |
| pdh-bundle-staleness-check.yml | npm-registry-availability-check | ⏭ skipped (needs workspace-version-bump-check) |
| pdh-partial-index-lint.yml | (skip, doesn't trigger on this path) | — |

## Action after observation

Close + delete branch. Do NOT merge.