### PR TITLE
feat(cli): one-line session resume — `agent --continue` + id-less `session resume` picker

### DIFF
--- a/packages/cli/__tests__/unit/recent-session.test.js
+++ b/packages/cli/__tests__/unit/recent-session.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/lib/session-manager.js", () => ({
+  listSessions: vi.fn(() => []),
+}));
+vi.mock("../../src/harness/jsonl-session-store.js", () => ({
+  listJsonlSessions: vi.fn(() => []),
+}));
+vi.mock("../../src/lib/feature-flags.js", () => ({
+  feature: vi.fn(() => true),
+}));
+
+const { listSessions } = await import("../../src/lib/session-manager.js");
+const { listJsonlSessions } =
+  await import("../../src/harness/jsonl-session-store.js");
+const { feature } = await import("../../src/lib/feature-flags.js");
+const { resolveMostRecentSessionId, listRecentSessions } =
+  await import("../../src/lib/recent-session.js");
+
+const fakeCtx = { db: { getDatabase: () => ({}) } };
+
+describe("resolveMostRecentSessionId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    feature.mockReturnValue(true);
+    listSessions.mockReturnValue([]);
+    listJsonlSessions.mockReturnValue([]);
+  });
+
+  it("returns null when no sessions exist", () => {
+    expect(resolveMostRecentSessionId(fakeCtx)).toBeNull();
+  });
+
+  it("returns null with no ctx and JSONL disabled", () => {
+    feature.mockReturnValue(false);
+    expect(resolveMostRecentSessionId(null)).toBeNull();
+  });
+
+  it("picks the newest updated_at across both stores", () => {
+    listSessions.mockReturnValue([
+      { id: "db-old", updated_at: "2026-01-01T00:00:00Z" },
+    ]);
+    listJsonlSessions.mockReturnValue([
+      { id: "jsonl-new", updated_at: "2026-06-08T00:00:00Z" },
+    ]);
+    expect(resolveMostRecentSessionId(fakeCtx)).toBe("jsonl-new");
+  });
+
+  it("dedups by id (keeps single entry)", () => {
+    listSessions.mockReturnValue([
+      { id: "dup", updated_at: "2026-06-08T00:00:00Z" },
+    ]);
+    listJsonlSessions.mockReturnValue([
+      { id: "dup", updated_at: "2026-06-08T00:00:00Z" },
+    ]);
+    expect(resolveMostRecentSessionId(fakeCtx)).toBe("dup");
+  });
+
+  it("skips JSONL store when feature flag is off", () => {
+    feature.mockReturnValue(false);
+    listSessions.mockReturnValue([
+      { id: "db-only", updated_at: "2026-06-08T00:00:00Z" },
+    ]);
+    listJsonlSessions.mockReturnValue([
+      { id: "jsonl-x", updated_at: "2026-06-09T00:00:00Z" },
+    ]);
+    expect(resolveMostRecentSessionId(fakeCtx)).toBe("db-only");
+    expect(listJsonlSessions).not.toHaveBeenCalled();
+  });
+
+  it("listRecentSessions returns full deduped newest-first list", () => {
+    listSessions.mockReturnValue([
+      { id: "a", updated_at: "2026-01-01T00:00:00Z" },
+      { id: "dup", updated_at: "2026-03-01T00:00:00Z" },
+    ]);
+    listJsonlSessions.mockReturnValue([
+      { id: "dup", updated_at: "2026-03-01T00:00:00Z" },
+      { id: "b", updated_at: "2026-06-08T00:00:00Z" },
+    ]);
+    const list = listRecentSessions(fakeCtx);
+    expect(list.map((s) => s.id)).toEqual(["b", "dup", "a"]);
+  });
+
+  it("survives a throwing db without crashing", () => {
+    const badCtx = {
+      db: {
+        getDatabase: () => {
+          throw new Error("db locked");
+        },
+      },
+    };
+    listJsonlSessions.mockReturnValue([
+      { id: "jsonl-ok", updated_at: "2026-06-08T00:00:00Z" },
+    ]);
+    expect(resolveMostRecentSessionId(badCtx)).toBe("jsonl-ok");
+  });
+});

--- a/packages/cli/src/commands/agent.js
+++ b/packages/cli/src/commands/agent.js
@@ -23,6 +23,10 @@ export function registerAgentCommand(program) {
     .option("--base-url <url>", "API base URL")
     .option("--api-key <key>", "API key")
     .option("--session <id>", "Resume a previous agent session")
+    .option(
+      "-c, --continue",
+      "Resume the most recent session (no id needed — claude --continue parity)",
+    )
     .option("--agent-id <id>", "Agent id for scoped memory recall")
     .option("--recall-limit <n>", "Top-K memories to inject into system prompt")
     .option("--recall-query <q>", "Query string for startup memory recall")
@@ -37,6 +41,24 @@ export function registerAgentCommand(program) {
       "Agent bundle directory (chainless-agent.toml + AGENTS.md + skills/ + mcp.json + USER.md)",
     )
     .action(async (options) => {
+      // `--continue` resolves the most recent session id so the user need not
+      // remember/copy it. Explicit `--session <id>` always wins.
+      if (options.continue && !options.session) {
+        const { bootstrap } = await import("../runtime/bootstrap.js");
+        const { resolveMostRecentSessionId } = await import(
+          "../lib/recent-session.js"
+        );
+        const ctx = await bootstrap({ verbose: program.opts().verbose });
+        const recent = resolveMostRecentSessionId(ctx);
+        if (!recent) {
+          process.stderr.write(
+            "No previous session to continue. Start one with `cc agent`.\n",
+          );
+          process.exit(1);
+        }
+        options.session = recent;
+      }
+
       const runtime = createAgentRuntimeFactory().createAgentRuntime({
         model: options.model,
         provider: options.provider,

--- a/packages/cli/src/commands/session.js
+++ b/packages/cli/src/commands/session.js
@@ -209,14 +209,56 @@ export function registerSessionCommand(program) {
   // session resume
   session
     .command("resume")
-    .description("Resume a session in chat mode")
-    .argument("<id>", "Session ID (or prefix)")
+    .description(
+      "Resume a session in chat mode (id optional — interactive picker, or most recent when piped)",
+    )
+    .argument(
+      "[id]",
+      "Session ID (or prefix); omit to pick / resume the most recent",
+    )
     .option("--model <model>", "Model name")
     .option("--provider <provider>", "LLM provider")
     .action(async (id, options) => {
       try {
         const ctx = await bootstrap({ verbose: program.opts().verbose });
         let sess = null;
+
+        // No id → interactive picker (TTY) or most-recent fallback (piped).
+        if (!id) {
+          const { listRecentSessions } =
+            await import("../lib/recent-session.js");
+          const recent = listRecentSessions(ctx);
+          if (recent.length === 0) {
+            logger.error(
+              "No saved sessions to resume. Use 'chat' or 'agent' to create one.",
+            );
+            process.exit(1);
+          }
+
+          if (process.stdin.isTTY && recent.length > 1) {
+            try {
+              const { select } = await import("@inquirer/prompts");
+              id = await select({
+                message: "Resume which session?",
+                choices: recent.map((s) => ({
+                  name: `${(s.title || "Untitled").slice(0, 50).padEnd(50)} ${chalk.cyan(
+                    (s.message_count ?? 0) + " msgs",
+                  )}  ${chalk.gray(s.updated_at || "")}${
+                    s._store === "jsonl" ? " " + chalk.yellow("[JSONL]") : ""
+                  }`,
+                  value: s.id,
+                  short: s.id.slice(0, 12),
+                })),
+              });
+            } catch {
+              // Ctrl+C / non-interactive — fall back to most recent.
+              id = recent[0].id;
+            }
+          } else {
+            // Single session or no TTY → most recent (claude --continue parity).
+            id = recent[0].id;
+          }
+        }
 
         // Try JSONL first
         if (feature("JSONL_SESSION") && sessionExists(id)) {

--- a/packages/cli/src/lib/recent-session.js
+++ b/packages/cli/src/lib/recent-session.js
@@ -1,0 +1,72 @@
+/**
+ * Resolve the most-recent session id across both stores (DB + JSONL).
+ *
+ * Shared by `cc agent --continue` and `cc session resume` (id-less form) so a
+ * user can pick up the last conversation with a one-liner — Claude-Code
+ * `claude --continue` parity.
+ */
+
+import { listSessions } from "./session-manager.js";
+import { listJsonlSessions } from "../harness/jsonl-session-store.js";
+import { feature } from "./feature-flags.js";
+
+/**
+ * Merge both stores into a single newest-first, id-deduped list.
+ *
+ * @param {object} ctx   bootstrap() context (may be null; db is optional)
+ * @param {object} [opts]
+ * @param {number} [opts.scan=20]  how many recent rows to merge per store
+ * @returns {Array<object>}  session rows (id, title, message_count, updated_at, _store)
+ */
+export function listRecentSessions(ctx, opts = {}) {
+  const scan = Math.max(1, opts.scan || 20);
+  const sessions = [];
+
+  if (ctx && ctx.db) {
+    try {
+      const db = ctx.db.getDatabase();
+      sessions.push(
+        ...listSessions(db, { limit: scan }).map((s) => ({
+          ...s,
+          _store: "db",
+        })),
+      );
+    } catch (err) {
+      /* db unavailable — fall through to JSONL */
+      void err;
+    }
+  }
+
+  if (feature("JSONL_SESSION")) {
+    try {
+      sessions.push(
+        ...listJsonlSessions({ limit: scan }).map((s) => ({
+          ...s,
+          _store: "jsonl",
+        })),
+      );
+    } catch (err) {
+      void err;
+    }
+  }
+
+  // Dedup by id (JSONL precedence via sort+seen), newest updated_at first.
+  const seen = new Set();
+  return sessions
+    .sort((a, b) => ((b.updated_at || "") > (a.updated_at || "") ? 1 : -1))
+    .filter((s) => {
+      if (!s || !s.id || seen.has(s.id)) return false;
+      seen.add(s.id);
+      return true;
+    });
+}
+
+/**
+ * @param {object} ctx   bootstrap() context (may be null; db is optional)
+ * @param {object} [opts] forwarded to {@link listRecentSessions}
+ * @returns {string|null}  the most-recently-updated session id, or null
+ */
+export function resolveMostRecentSessionId(ctx, opts = {}) {
+  const sessions = listRecentSessions(ctx, opts);
+  return sessions.length > 0 ? sessions[0].id : null;
+}


### PR DESCRIPTION
## What

Claude-Code `claude --continue` parity for the `cc` CLI. Previously resuming a session required `cc session resume <id>` — you had to look the id up via `cc session list` and paste it.

- **`cc agent -c/--continue`** — resume the most recent session, no id needed.
- **`cc session resume`** (id now optional) — interactive arrow-key **picker** on a TTY with >1 session; a single session or piped/non-TTY input falls back to the most recent so headless runs never block.

## How

- New shared resolver `src/lib/recent-session.js`:
  - `listRecentSessions(ctx)` — merges the DB + JSONL stores, newest-first, id-deduped (JSONL precedence). Feeds the picker.
  - `resolveMostRecentSessionId(ctx)` — thin wrapper. Feeds `--continue`.
- `cc agent` gains `-c, --continue`; explicit `--session <id>` always wins.
- `cc session resume <id>` → `[id]`; picker reuses `@inquirer/prompts` `select` (already a dep, same pattern as `cc init`). Picker only triggers behind a `process.stdin.isTTY` guard, so headless/piped runs take the most-recent fallback.

## Tests

- 7 unit tests in `__tests__/unit/recent-session.test.js` (empty / flag-off / cross-store newest / dedup / db-throw / full-list order). All green; eslint clean.
- Picker's arrow-key flow itself isn't unit-testable without a PTY (same as the existing `cc init` selector) — it's behind the TTY guard; tests cover the list-building logic that feeds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)