### PR TITLE
fix(ios): PIN 输入闪退(DB死锁) + 去中心化社交对齐(动态广场+好友系统)

### DIFF
--- a/ios-app/ChainlessChain.xcodeproj/project.pbxproj
+++ b/ios-app/ChainlessChain.xcodeproj/project.pbxproj
@@ -33,6 +33,18 @@
 		333E7CC1D5B18E3BD57F9D89 /* RemoteBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72139FA75E27E8DDC4B21A7F /* RemoteBrowserView.swift */; };
 		3340FC1074E029178C3D5928 /* IntentUnderstandingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D65B47DA8B60BAA96960C5C /* IntentUnderstandingService.swift */; };
 		366B1EEBFC5EB1B8FAD0F3B5 /* SocialFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2714270CED201264AC6460 /* SocialFeedView.swift */; };
+		FE5009B100000000000000B1 /* SocialPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009A100000000000000A1 /* SocialPost.swift */; };
+		FE5009B200000000000000B2 /* SocialRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009A200000000000000A2 /* SocialRepository.swift */; };
+		FE5009B300000000000000B3 /* SocialFeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009A300000000000000A3 /* SocialFeedViewModel.swift */; };
+		FE5009B400000000000000B4 /* PublishPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009A400000000000000A4 /* PublishPostView.swift */; };
+		FE5009B500000000000000B5 /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009A500000000000000A5 /* PostDetailView.swift */; };
+		FE5009D100000000000000D1 /* FriendsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009C100000000000000C1 /* FriendsViewModel.swift */; };
+		FE5009D200000000000000D2 /* FriendListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009C200000000000000C2 /* FriendListView.swift */; };
+		FE5009D300000000000000D3 /* AddFriendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009C300000000000000C3 /* AddFriendView.swift */; };
+		FE5009D400000000000000D4 /* FriendDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009C400000000000000C4 /* FriendDetailView.swift */; };
+		FE5009D500000000000000D5 /* BlockedUsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009C500000000000000C5 /* BlockedUsersView.swift */; };
+		FE5009D600000000000000D6 /* UserPostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009C600000000000000C6 /* UserPostsView.swift */; };
+		FE5009D700000000000000D7 /* MyDIDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5009C700000000000000C7 /* MyDIDView.swift */; };
 		368995B347BB5ED4E39435E0 /* ProjectAIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732AFB61FA1B6BA9F9F6BF40 /* ProjectAIManager.swift */; };
 		3CA26E1824D81DADC04FAD04 /* ImageStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2608689829ED73A12B5F641 /* ImageStorageManager.swift */; };
 		3D84AACB4102CE896326A77D /* RecordingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B88B9832F862383826B971 /* RecordingListView.swift */; };
@@ -275,6 +287,18 @@
 		E99D0409733F669F306B67DA /* ElementHighlighter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementHighlighter.swift; path = ./ChainlessChain/Features/ComputerUse/Services/ElementHighlighter.swift; sourceTree = "<group>"; };
 		EA4D3C05603995C161C99970 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsView.swift; path = ./ChainlessChain/Features/Settings/Views/SettingsView.swift; sourceTree = "<group>"; };
 		EC2714270CED201264AC6460 /* SocialFeedView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SocialFeedView.swift; path = ./ChainlessChain/Features/Social/Views/SocialFeedView.swift; sourceTree = "<group>"; };
+		FE5009A100000000000000A1 /* SocialPost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SocialPost.swift; path = ./ChainlessChain/Features/Social/Models/SocialPost.swift; sourceTree = "<group>"; };
+		FE5009A200000000000000A2 /* SocialRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SocialRepository.swift; path = ./ChainlessChain/Features/Social/Services/SocialRepository.swift; sourceTree = "<group>"; };
+		FE5009A300000000000000A3 /* SocialFeedViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SocialFeedViewModel.swift; path = ./ChainlessChain/Features/Social/ViewModels/SocialFeedViewModel.swift; sourceTree = "<group>"; };
+		FE5009A400000000000000A4 /* PublishPostView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PublishPostView.swift; path = ./ChainlessChain/Features/Social/Views/PublishPostView.swift; sourceTree = "<group>"; };
+		FE5009A500000000000000A5 /* PostDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostDetailView.swift; path = ./ChainlessChain/Features/Social/Views/PostDetailView.swift; sourceTree = "<group>"; };
+		FE5009C100000000000000C1 /* FriendsViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FriendsViewModel.swift; path = ./ChainlessChain/Features/Social/ViewModels/FriendsViewModel.swift; sourceTree = "<group>"; };
+		FE5009C200000000000000C2 /* FriendListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FriendListView.swift; path = ./ChainlessChain/Features/Social/Views/FriendListView.swift; sourceTree = "<group>"; };
+		FE5009C300000000000000C3 /* AddFriendView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AddFriendView.swift; path = ./ChainlessChain/Features/Social/Views/AddFriendView.swift; sourceTree = "<group>"; };
+		FE5009C400000000000000C4 /* FriendDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FriendDetailView.swift; path = ./ChainlessChain/Features/Social/Views/FriendDetailView.swift; sourceTree = "<group>"; };
+		FE5009C500000000000000C5 /* BlockedUsersView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockedUsersView.swift; path = ./ChainlessChain/Features/Social/Views/BlockedUsersView.swift; sourceTree = "<group>"; };
+		FE5009C600000000000000C6 /* UserPostsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserPostsView.swift; path = ./ChainlessChain/Features/Social/Views/UserPostsView.swift; sourceTree = "<group>"; };
+		FE5009C700000000000000C7 /* MyDIDView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MyDIDView.swift; path = ./ChainlessChain/Features/Social/Views/MyDIDView.swift; sourceTree = "<group>"; };
 		ED4B83C162BCFBD9DC0647FD /* MessageManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MessageManager.swift; path = ./ChainlessChain/Features/Social/Services/MessageManager.swift; sourceTree = "<group>"; };
 		F010556B9D5579AEDAE02443 /* ComputerUseTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ComputerUseTypes.swift; path = ./ChainlessChain/Features/ComputerUse/Models/ComputerUseTypes.swift; sourceTree = "<group>"; };
 		F0435AA490476517B94AE2FA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -349,6 +373,7 @@
 				790BB7D492AEE9CC85253673 /* OfflineMessageQueue.swift */,
 				48631B8C1263C905AAB2F71E /* MessageStatusManager.swift */,
 				CC62BDC254550A9098A68D56 /* WebRTCManager.swift */,
+				FE5009A200000000000000A2 /* SocialRepository.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -484,6 +509,8 @@
 			children = (
 				8FE510F1EE7A7FE7FA7B281F /* P2PViewModel.swift */,
 				9E9ABC912104F75749E37B15 /* GroupChatViewModel.swift */,
+				FE5009A300000000000000A3 /* SocialFeedViewModel.swift */,
+				FE5009C100000000000000C1 /* FriendsViewModel.swift */,
 			);
 			name = ViewModels;
 			sourceTree = "<group>";
@@ -535,6 +562,7 @@
 		70343107AE177B175C36EFE4 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				FE5009A100000000000000A1 /* SocialPost.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -927,6 +955,14 @@
 				1D569285B5CBD46DA3D8A82F /* P2PChatView.swift */,
 				541484F5325784212A983066 /* ConversationListView.swift */,
 				EC2714270CED201264AC6460 /* SocialFeedView.swift */,
+				FE5009A400000000000000A4 /* PublishPostView.swift */,
+				FE5009A500000000000000A5 /* PostDetailView.swift */,
+				FE5009C200000000000000C2 /* FriendListView.swift */,
+				FE5009C300000000000000C3 /* AddFriendView.swift */,
+				FE5009C400000000000000C4 /* FriendDetailView.swift */,
+				FE5009C500000000000000C5 /* BlockedUsersView.swift */,
+				FE5009C600000000000000C6 /* UserPostsView.swift */,
+				FE5009C700000000000000C7 /* MyDIDView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1048,6 +1084,18 @@
 				2C973CFA77E9206051319183 /* P2PChatView.swift in Sources */,
 				256DB890DE3F355B4C925932 /* ConversationListView.swift in Sources */,
 				366B1EEBFC5EB1B8FAD0F3B5 /* SocialFeedView.swift in Sources */,
+				FE5009B100000000000000B1 /* SocialPost.swift in Sources */,
+				FE5009B200000000000000B2 /* SocialRepository.swift in Sources */,
+				FE5009B300000000000000B3 /* SocialFeedViewModel.swift in Sources */,
+				FE5009B400000000000000B4 /* PublishPostView.swift in Sources */,
+				FE5009B500000000000000B5 /* PostDetailView.swift in Sources */,
+				FE5009D100000000000000D1 /* FriendsViewModel.swift in Sources */,
+				FE5009D200000000000000D2 /* FriendListView.swift in Sources */,
+				FE5009D300000000000000D3 /* AddFriendView.swift in Sources */,
+				FE5009D400000000000000D4 /* FriendDetailView.swift in Sources */,
+				FE5009D500000000000000D5 /* BlockedUsersView.swift in Sources */,
+				FE5009D600000000000000D6 /* UserPostsView.swift in Sources */,
+				FE5009D700000000000000D7 /* MyDIDView.swift in Sources */,
 				CF0C6E6D6B3756453AB34393 /* P2PContactRepository.swift in Sources */,
 				29B95258A1AC762A396B6517 /* SignalProtocolManager.swift in Sources */,
 				EA74381E5FE78EE235259279 /* P2PManager.swift in Sources */,

--- a/ios-app/ChainlessChain/Features/Social/Models/SocialPost.swift
+++ b/ios-app/ChainlessChain/Features/Social/Models/SocialPost.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// 帖子可见性（与 Android `PostEntity.visibility` 对齐）
+enum PostVisibility: String, CaseIterable, Identifiable {
+    case publicAll = "public"
+    case friends = "friends"
+    case privateOnly = "private"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .publicAll: return "公开"
+        case .friends: return "仅好友"
+        case .privateOnly: return "仅自己"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .publicAll: return "globe"
+        case .friends: return "person.2"
+        case .privateOnly: return "lock"
+        }
+    }
+}
+
+/// 去中心化社交「动态」帖子
+struct SocialPost: Identifiable, Equatable {
+    let id: String
+    let authorDID: String
+    var content: String
+    var mediaURLs: [String]
+    var likeCount: Int
+    var commentCount: Int
+    var shareCount: Int
+    var isLiked: Bool
+    var visibility: PostVisibility
+    let createdAt: Date
+    var updatedAt: Date
+
+    /// 作者展示名（DID 末尾片段兜底；好友昵称由调用方覆盖）
+    var displayAuthor: String {
+        if authorDID.count > 12 {
+            return "…" + authorDID.suffix(8)
+        }
+        return authorDID
+    }
+
+    static func == (lhs: SocialPost, rhs: SocialPost) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.content == rhs.content &&
+        lhs.likeCount == rhs.likeCount &&
+        lhs.commentCount == rhs.commentCount &&
+        lhs.isLiked == rhs.isLiked
+    }
+}
+
+/// 帖子评论
+struct SocialComment: Identifiable, Equatable {
+    let id: String
+    let postID: String
+    let authorDID: String
+    var content: String
+    let parentCommentID: String?
+    let createdAt: Date
+
+    var displayAuthor: String {
+        if authorDID.count > 12 {
+            return "…" + authorDID.suffix(8)
+        }
+        return authorDID
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Services/SocialRepository.swift
+++ b/ios-app/ChainlessChain/Features/Social/Services/SocialRepository.swift
@@ -1,0 +1,184 @@
+import Foundation
+import SQLite3
+import CoreCommon
+import CoreDatabase
+
+/// 去中心化社交「动态」仓储（帖子 / 评论 / 点赞）。
+/// 与 Android `PostRepository` / `PostInteractionDao` 对齐。
+/// 作者 DID 由调用方（@MainActor 的 ViewModel）从 `AppState.currentDID` 传入，
+/// 避免在非主线程上下文里访问 @MainActor 隔离的全局状态。
+class SocialRepository {
+    static let shared = SocialRepository()
+
+    private let logger = Logger.shared
+    private let db = DatabaseManager.shared
+
+    private init() {}
+
+    // MARK: - Posts
+
+    @discardableResult
+    func createPost(authorDID: String, content: String, visibility: PostVisibility, mediaURLs: [String] = []) throws -> SocialPost {
+        let id = UUID().uuidString
+        let now = Date()
+        let ts = now.timestampMs
+        let media = mediaURLs.joined(separator: ",")
+
+        let sql = """
+            INSERT INTO social_posts (
+                id, author_did, content, media_urls, like_count, comment_count,
+                share_count, is_liked, visibility, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, 0, 0, 0, 0, ?, ?, ?);
+        """
+        try db.execute(sql, parameters: [id, authorDID, content, media, visibility.rawValue, ts, ts])
+        logger.info("Created social post: \(id)", category: "Social")
+
+        return SocialPost(
+            id: id, authorDID: authorDID, content: content, mediaURLs: mediaURLs,
+            likeCount: 0, commentCount: 0, shareCount: 0, isLiked: false,
+            visibility: visibility, createdAt: now, updatedAt: now
+        )
+    }
+
+    /// 时间线：公开 + 仅好友的帖子，外加自己的全部帖子（含 private）。
+    func getFeed(currentDID: String, limit: Int = 100, offset: Int = 0) throws -> [SocialPost] {
+        let sql = """
+            SELECT p.id, p.author_did, p.content, p.media_urls, p.like_count,
+                   p.comment_count, p.share_count, p.visibility, p.created_at, p.updated_at,
+                   CASE WHEN l.liker_did IS NOT NULL THEN 1 ELSE 0 END AS is_liked
+            FROM social_posts p
+            LEFT JOIN social_post_likes l ON l.post_id = p.id AND l.liker_did = ?
+            WHERE p.visibility != 'private' OR p.author_did = ?
+            ORDER BY p.created_at DESC
+            LIMIT ? OFFSET ?;
+        """
+        return try db.query(sql, parameters: [currentDID, currentDID, limit, offset], mapper: mapPost)
+    }
+
+    func getUserPosts(authorDID: String, currentDID: String, limit: Int = 100) throws -> [SocialPost] {
+        let sql = """
+            SELECT p.id, p.author_did, p.content, p.media_urls, p.like_count,
+                   p.comment_count, p.share_count, p.visibility, p.created_at, p.updated_at,
+                   CASE WHEN l.liker_did IS NOT NULL THEN 1 ELSE 0 END AS is_liked
+            FROM social_posts p
+            LEFT JOIN social_post_likes l ON l.post_id = p.id AND l.liker_did = ?
+            WHERE p.author_did = ?
+            ORDER BY p.created_at DESC
+            LIMIT ?;
+        """
+        return try db.query(sql, parameters: [currentDID, authorDID, limit], mapper: mapPost)
+    }
+
+    func deletePost(id: String) throws {
+        try db.execute("DELETE FROM social_post_likes WHERE post_id = ?;", parameters: [id])
+        try db.execute("DELETE FROM social_post_comments WHERE post_id = ?;", parameters: [id])
+        try db.execute("DELETE FROM social_posts WHERE id = ?;", parameters: [id])
+        logger.info("Deleted social post: \(id)", category: "Social")
+    }
+
+    /// 点赞 / 取消点赞，返回最新 (isLiked, likeCount)。
+    @discardableResult
+    func toggleLike(postID: String, likerDID: String) throws -> (isLiked: Bool, likeCount: Int) {
+        let existing: Int = try db.queryOne(
+            "SELECT COUNT(*) FROM social_post_likes WHERE post_id = ? AND liker_did = ?;",
+            parameters: [postID, likerDID]
+        ) { stmt in Int(sqlite3_column_int(stmt, 0)) } ?? 0
+
+        if existing > 0 {
+            try db.execute("DELETE FROM social_post_likes WHERE post_id = ? AND liker_did = ?;", parameters: [postID, likerDID])
+            try db.execute("UPDATE social_posts SET like_count = MAX(like_count - 1, 0), is_liked = 0 WHERE id = ?;", parameters: [postID])
+        } else {
+            try db.execute(
+                "INSERT INTO social_post_likes (post_id, liker_did, created_at) VALUES (?, ?, ?);",
+                parameters: [postID, likerDID, Date().timestampMs]
+            )
+            try db.execute("UPDATE social_posts SET like_count = like_count + 1, is_liked = 1 WHERE id = ?;", parameters: [postID])
+        }
+
+        let count: Int = try db.queryOne("SELECT like_count FROM social_posts WHERE id = ?;", parameters: [postID]) { stmt in
+            Int(sqlite3_column_int(stmt, 0))
+        } ?? 0
+        return (isLiked: existing == 0, likeCount: count)
+    }
+
+    // MARK: - Comments
+
+    @discardableResult
+    func addComment(postID: String, authorDID: String, content: String, parentCommentID: String? = nil) throws -> SocialComment {
+        let id = UUID().uuidString
+        let now = Date()
+        try db.execute(
+            "INSERT INTO social_post_comments (id, post_id, author_did, content, parent_comment_id, created_at) VALUES (?, ?, ?, ?, ?, ?);",
+            parameters: [id, postID, authorDID, content, parentCommentID, now.timestampMs]
+        )
+        try db.execute("UPDATE social_posts SET comment_count = comment_count + 1 WHERE id = ?;", parameters: [postID])
+        logger.info("Added comment \(id) to post \(postID)", category: "Social")
+
+        return SocialComment(
+            id: id, postID: postID, authorDID: authorDID,
+            content: content, parentCommentID: parentCommentID, createdAt: now
+        )
+    }
+
+    func getComments(postID: String) throws -> [SocialComment] {
+        let sql = """
+            SELECT id, post_id, author_did, content, parent_comment_id, created_at
+            FROM social_post_comments
+            WHERE post_id = ?
+            ORDER BY created_at ASC;
+        """
+        return try db.query(sql, parameters: [postID], mapper: mapComment)
+    }
+
+    func deleteComment(id: String, postID: String) throws {
+        try db.execute("DELETE FROM social_post_comments WHERE id = ?;", parameters: [id])
+        try db.execute("UPDATE social_posts SET comment_count = MAX(comment_count - 1, 0) WHERE id = ?;", parameters: [postID])
+    }
+
+    // MARK: - Mappers
+
+    private func mapPost(_ stmt: OpaquePointer) -> SocialPost? {
+        guard let idC = sqlite3_column_text(stmt, 0),
+              let authorC = sqlite3_column_text(stmt, 1),
+              let contentC = sqlite3_column_text(stmt, 2) else {
+            return nil
+        }
+
+        let mediaStr = sqlite3_column_text(stmt, 3).map { String(cString: $0) } ?? ""
+        let media = mediaStr.isEmpty ? [] : mediaStr.split(separator: ",").map(String.init)
+        let visStr = sqlite3_column_text(stmt, 7).map { String(cString: $0) } ?? "public"
+
+        return SocialPost(
+            id: String(cString: idC),
+            authorDID: String(cString: authorC),
+            content: String(cString: contentC),
+            mediaURLs: media,
+            likeCount: Int(sqlite3_column_int(stmt, 4)),
+            commentCount: Int(sqlite3_column_int(stmt, 5)),
+            shareCount: Int(sqlite3_column_int(stmt, 6)),
+            isLiked: Int(sqlite3_column_int(stmt, 10)) == 1,
+            visibility: PostVisibility(rawValue: visStr) ?? .publicAll,
+            createdAt: Date(timestampMs: sqlite3_column_int64(stmt, 8)),
+            updatedAt: Date(timestampMs: sqlite3_column_int64(stmt, 9))
+        )
+    }
+
+    private func mapComment(_ stmt: OpaquePointer) -> SocialComment? {
+        guard let idC = sqlite3_column_text(stmt, 0),
+              let postC = sqlite3_column_text(stmt, 1),
+              let authorC = sqlite3_column_text(stmt, 2),
+              let contentC = sqlite3_column_text(stmt, 3) else {
+            return nil
+        }
+        let parent = sqlite3_column_text(stmt, 4).map { String(cString: $0) }
+
+        return SocialComment(
+            id: String(cString: idC),
+            postID: String(cString: postC),
+            authorDID: String(cString: authorC),
+            content: String(cString: contentC),
+            parentCommentID: parent,
+            createdAt: Date(timestampMs: sqlite3_column_int64(stmt, 5))
+        )
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/ViewModels/FriendsViewModel.swift
+++ b/ios-app/ChainlessChain/Features/Social/ViewModels/FriendsViewModel.swift
@@ -1,0 +1,143 @@
+import Foundation
+import SwiftUI
+import CoreCommon
+import CoreDID
+
+/// 好友（去中心化联系人）管理 ViewModel。
+/// 复用已有的 `P2PContactRepository`（`p2p_contacts` 表），补齐 Android
+/// `FriendListScreen` / `AddFriendScreen` / `BlockedUsersScreen` 对应的 UI 层。
+@MainActor
+class FriendsViewModel: ObservableObject {
+    @Published var friends: [P2PContactEntity] = []
+    @Published var blocked: [P2PContactEntity] = []
+    @Published var searchText = ""
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let repository = P2PContactRepository.shared
+    private let messageRepository = P2PMessageRepository.shared
+    private let logger = Logger.shared
+
+    var myDID: String { DIDManager.shared.currentDID?.did ?? "" }
+
+    var filteredFriends: [P2PContactEntity] {
+        guard !searchText.isEmpty else { return friends }
+        return friends.filter {
+            $0.name.localizedCaseInsensitiveContains(searchText) ||
+            $0.did.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    // MARK: - Loading
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            friends = try repository.getAllContacts(includeBlocked: false)
+        } catch {
+            logger.error("Failed to load friends", error: error, category: "Social")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadBlocked() async {
+        do {
+            blocked = try repository.getAllContacts(includeBlocked: true).filter { $0.isBlocked }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Add by DID
+
+    /// 通过 DID 添加好友，返回是否成功。
+    @discardableResult
+    func addFriend(did rawDid: String, name rawName: String) -> Bool {
+        let did = rawDid.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard did.hasPrefix("did:") else {
+            errorMessage = "请输入有效的 DID（以 did: 开头）"
+            return false
+        }
+        guard did != myDID else {
+            errorMessage = "不能添加自己为好友"
+            return false
+        }
+
+        do {
+            if let existing = try repository.getContactByDid(did: did) {
+                errorMessage = "「\(existing.displayName)」已在你的好友列表中"
+                return false
+            }
+            let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+            let display = name.isEmpty ? (String(did.prefix(16)) + "…") : name
+            let contact = P2PContactEntity(did: did, name: display)
+            try repository.addContact(contact)
+            friends.insert(contact, at: 0)
+            logger.info("Added friend by DID", category: "Social")
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    // MARK: - Mutations
+
+    func setVerified(_ contact: P2PContactEntity, verified: Bool) {
+        do {
+            try repository.setVerified(id: contact.id, verified: verified)
+            if let idx = friends.firstIndex(where: { $0.id == contact.id }) {
+                friends[idx].isVerified = verified
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func setBlocked(_ contact: P2PContactEntity, blocked: Bool) async {
+        do {
+            try repository.setBlocked(id: contact.id, blocked: blocked)
+            await load()
+            await loadBlocked()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteFriend(_ contact: P2PContactEntity) {
+        do {
+            try repository.deleteContact(id: contact.id)
+            friends.removeAll { $0.id == contact.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func rename(_ contact: P2PContactEntity, to newName: String) {
+        let name = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+        do {
+            try repository.updateContactName(id: contact.id, name: name)
+            if let idx = friends.firstIndex(where: { $0.id == contact.id }) {
+                friends[idx].name = name
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// 创建/获取与该好友的会话（之后会出现在「消息」列表），返回是否成功。
+    @discardableResult
+    func startChat(with contact: P2PContactEntity) -> Bool {
+        do {
+            _ = try messageRepository.getOrCreateConversation(with: contact.did, myDid: myDID)
+            return true
+        } catch {
+            logger.error("Failed to start chat from friend detail", error: error, category: "Social")
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/ViewModels/SocialFeedViewModel.swift
+++ b/ios-app/ChainlessChain/Features/Social/ViewModels/SocialFeedViewModel.swift
@@ -1,0 +1,127 @@
+import Foundation
+import SwiftUI
+import CoreCommon
+
+/// 社交「广场」时间线 ViewModel
+@MainActor
+class SocialFeedViewModel: ObservableObject {
+    @Published var posts: [SocialPost] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let repository = SocialRepository.shared
+    private let logger = Logger.shared
+
+    private var currentDID: String { AppState.shared.currentDID ?? "" }
+
+    func loadFeed() async {
+        guard !currentDID.isEmpty else {
+            posts = []
+            return
+        }
+
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            posts = try repository.getFeed(currentDID: currentDID)
+        } catch {
+            logger.error("Failed to load social feed", error: error, category: "Social")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func refresh() async {
+        await loadFeed()
+    }
+
+    func publish(content: String, visibility: PostVisibility) async {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !currentDID.isEmpty else { return }
+
+        do {
+            let post = try repository.createPost(authorDID: currentDID, content: trimmed, visibility: visibility)
+            posts.insert(post, at: 0)
+        } catch {
+            logger.error("Failed to publish post", error: error, category: "Social")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func toggleLike(_ post: SocialPost) {
+        guard !currentDID.isEmpty else { return }
+        do {
+            let result = try repository.toggleLike(postID: post.id, likerDID: currentDID)
+            if let idx = posts.firstIndex(where: { $0.id == post.id }) {
+                posts[idx].isLiked = result.isLiked
+                posts[idx].likeCount = result.likeCount
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deletePost(_ post: SocialPost) {
+        do {
+            try repository.deletePost(id: post.id)
+            posts.removeAll { $0.id == post.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func canDelete(_ post: SocialPost) -> Bool {
+        post.authorDID == currentDID
+    }
+}
+
+/// 动态详情（评论）ViewModel
+@MainActor
+class PostDetailViewModel: ObservableObject {
+    @Published var comments: [SocialComment] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    let post: SocialPost
+    private let repository = SocialRepository.shared
+
+    private var currentDID: String { AppState.shared.currentDID ?? "" }
+
+    init(post: SocialPost) {
+        self.post = post
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            comments = try repository.getComments(postID: post.id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func addComment(_ content: String) async {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !currentDID.isEmpty else { return }
+        do {
+            let comment = try repository.addComment(postID: post.id, authorDID: currentDID, content: trimmed)
+            comments.append(comment)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func canDelete(_ comment: SocialComment) -> Bool {
+        comment.authorDID == currentDID
+    }
+
+    func deleteComment(_ comment: SocialComment) {
+        do {
+            try repository.deleteComment(id: comment.id, postID: post.id)
+            comments.removeAll { $0.id == comment.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Views/AddFriendView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/AddFriendView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// 通过 DID 添加好友（与 Android `AddFriendScreen` 对齐）
+struct AddFriendView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var viewModel: FriendsViewModel
+
+    @State private var did = ""
+    @State private var name = ""
+
+    private var canSubmit: Bool {
+        !did.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("好友 DID")) {
+                    TextField("did:key:… 或 did:chainlesschain:…", text: $did)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                        .font(.system(.body, design: .monospaced))
+                }
+
+                Section(header: Text("备注名（可选）")) {
+                    TextField("好友昵称", text: $name)
+                }
+
+                Section {
+                    Button(action: submit) {
+                        Text("添加好友")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .disabled(!canSubmit)
+                }
+
+                Section {
+                    Text("好友身份基于去中心化 DID，无需手机号或账号。对方可在「我的二维码」中分享自己的 DID。")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+            }
+            .navigationTitle("添加好友")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("取消") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func submit() {
+        if viewModel.addFriend(did: did, name: name) {
+            dismiss()
+        }
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Views/BlockedUsersView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/BlockedUsersView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// 已屏蔽用户管理（与 Android `BlockedUsersScreen` 对齐）
+struct BlockedUsersView: View {
+    @ObservedObject var viewModel: FriendsViewModel
+
+    var body: some View {
+        ZStack {
+            if viewModel.blocked.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "hand.raised.slash")
+                        .font(.largeTitle)
+                        .foregroundColor(.gray)
+                    Text("没有被屏蔽的用户")
+                        .foregroundColor(.gray)
+                }
+            } else {
+                List {
+                    ForEach(viewModel.blocked) { contact in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(contact.displayName)
+                                    .font(.headline)
+                                Text(String(contact.did.prefix(24)) + "…")
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+                                    .lineLimit(1)
+                            }
+                            Spacer()
+                            Button("解除屏蔽") {
+                                Task { await viewModel.setBlocked(contact, blocked: false) }
+                            }
+                            .buttonStyle(.borderless)
+                            .foregroundColor(.blue)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("已屏蔽")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.loadBlocked()
+        }
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Views/ConversationListView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/ConversationListView.swift
@@ -5,6 +5,8 @@ import CoreDID
 struct ConversationListView: View {
     @StateObject private var viewModel = ConversationListViewModel()
     @State private var showNewChat = false
+    @State private var showSocialFeed = false
+    @State private var showFriends = false
 
     var body: some View {
         NavigationView {
@@ -19,6 +21,19 @@ struct ConversationListView: View {
             }
             .navigationTitle("消息")
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Menu {
+                        Button(action: { showSocialFeed = true }) {
+                            Label("社交广场", systemImage: "person.3")
+                        }
+                        Button(action: { showFriends = true }) {
+                            Label("好友", systemImage: "person.2")
+                        }
+                    } label: {
+                        Image(systemName: "person.2.circle")
+                    }
+                    .accessibilityLabel("社交")
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showNewChat = true }) {
                         Image(systemName: "square.and.pencil")
@@ -30,6 +45,12 @@ struct ConversationListView: View {
                     viewModel.startConversation(with: contact)
                     showNewChat = false
                 }
+            }
+            .sheet(isPresented: $showSocialFeed) {
+                SocialFeedView()
+            }
+            .sheet(isPresented: $showFriends) {
+                FriendListView()
             }
             .refreshable {
                 await viewModel.loadConversations()

--- a/ios-app/ChainlessChain/Features/Social/Views/FriendDetailView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/FriendDetailView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// 好友资料 + 操作（与 Android `FriendDetailScreen` 对齐）
+struct FriendDetailView: View {
+    let contact: P2PContactEntity
+    @ObservedObject var viewModel: FriendsViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var isVerified: Bool
+    @State private var chatStartedAlert = false
+
+    init(contact: P2PContactEntity, viewModel: FriendsViewModel) {
+        self.contact = contact
+        self.viewModel = viewModel
+        _isVerified = State(initialValue: contact.isVerified)
+    }
+
+    var body: some View {
+        List {
+            Section {
+                HStack(spacing: 16) {
+                    Circle()
+                        .fill(Color.blue.opacity(0.2))
+                        .frame(width: 64, height: 64)
+                        .overlay(
+                            Text(contact.initials.isEmpty ? "?" : contact.initials)
+                                .font(.title)
+                                .foregroundColor(.blue)
+                        )
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(contact.displayName)
+                            .font(.title3)
+                            .fontWeight(.semibold)
+                        if isVerified {
+                            Label("已验证", systemImage: "checkmark.seal.fill")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        } else {
+                            Text("未验证")
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+                    }
+                }
+                .padding(.vertical, 6)
+            }
+
+            Section(header: Text("DID")) {
+                Text(contact.did)
+                    .font(.system(.footnote, design: .monospaced))
+                    .textSelection(.enabled)
+            }
+
+            Section {
+                Button {
+                    if viewModel.startChat(with: contact) {
+                        chatStartedAlert = true
+                    }
+                } label: {
+                    Label("发消息", systemImage: "message")
+                }
+
+                NavigationLink(destination: UserPostsView(authorDID: contact.did, title: contact.displayName)) {
+                    Label("查看 TA 的动态", systemImage: "list.bullet.rectangle")
+                }
+            }
+
+            Section {
+                Toggle(isOn: $isVerified) {
+                    Label("标记为已验证", systemImage: "checkmark.shield")
+                }
+                .onChange(of: isVerified) { newValue in
+                    viewModel.setVerified(contact, verified: newValue)
+                }
+
+                Button {
+                    Task {
+                        await viewModel.setBlocked(contact, blocked: true)
+                        dismiss()
+                    }
+                } label: {
+                    Label("屏蔽该好友", systemImage: "hand.raised")
+                        .foregroundColor(.orange)
+                }
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    viewModel.deleteFriend(contact)
+                    dismiss()
+                } label: {
+                    Label("删除好友", systemImage: "trash")
+                }
+            }
+        }
+        .navigationTitle("好友资料")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("对话已就绪", isPresented: $chatStartedAlert) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text("已为你创建与 \(contact.displayName) 的会话，请到「消息」列表查看。")
+        }
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Views/FriendListView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/FriendListView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import CoreCommon
+
+/// 好友列表（与 Android `FriendListScreen` 对齐）
+struct FriendListView: View {
+    @StateObject private var viewModel = FriendsViewModel()
+    @State private var showAddFriend = false
+    @State private var showMyDID = false
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                if viewModel.isLoading && viewModel.friends.isEmpty {
+                    ProgressView("加载中...")
+                } else if viewModel.friends.isEmpty {
+                    emptyView
+                } else {
+                    friendList
+                }
+            }
+            .navigationTitle("好友")
+            .searchable(text: $viewModel.searchText, prompt: "搜索好友或 DID")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: { showMyDID = true }) {
+                        Image(systemName: "qrcode")
+                    }
+                    .accessibilityLabel("我的二维码")
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showAddFriend = true }) {
+                        Image(systemName: "person.badge.plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showAddFriend) {
+                AddFriendView(viewModel: viewModel)
+            }
+            .sheet(isPresented: $showMyDID) {
+                MyDIDView(did: viewModel.myDID)
+            }
+            .refreshable {
+                await viewModel.load()
+            }
+        }
+        .task {
+            await viewModel.load()
+        }
+    }
+
+    private var friendList: some View {
+        List {
+            Section {
+                ForEach(viewModel.filteredFriends) { friend in
+                    NavigationLink(destination: FriendDetailView(contact: friend, viewModel: viewModel)) {
+                        FriendRow(contact: friend)
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            viewModel.deleteFriend(friend)
+                        } label: {
+                            Label("删除", systemImage: "trash")
+                        }
+                        Button {
+                            Task { await viewModel.setBlocked(friend, blocked: true) }
+                        } label: {
+                            Label("屏蔽", systemImage: "hand.raised")
+                        }
+                        .tint(.orange)
+                    }
+                }
+            }
+
+            Section {
+                NavigationLink(destination: BlockedUsersView(viewModel: viewModel)) {
+                    Label("已屏蔽的用户", systemImage: "hand.raised.slash")
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "person.2.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 80, height: 60)
+                .foregroundColor(.gray)
+
+            Text("还没有好友")
+                .font(.headline)
+                .foregroundColor(.gray)
+
+            Text("通过 DID 添加好友，开始去中心化社交")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+
+            Button(action: { showAddFriend = true }) {
+                Label("添加好友", systemImage: "person.badge.plus")
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Friend Row
+
+struct FriendRow: View {
+    let contact: P2PContactEntity
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(Color.blue.opacity(0.2))
+                .frame(width: 44, height: 44)
+                .overlay(
+                    Text(contact.initials.isEmpty ? "?" : contact.initials)
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Text(contact.displayName)
+                        .font(.headline)
+                    if contact.isVerified {
+                        Image(systemName: "checkmark.seal.fill")
+                            .font(.caption)
+                            .foregroundColor(.blue)
+                    }
+                }
+                Text(String(contact.did.prefix(24)) + "…")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Views/MyDIDView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/MyDIDView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import UIKit
+import CoreImage.CIFilterBuiltins
+
+/// 我的 DID + 二维码（与 Android `MyQRCodeScreen` 对齐）。
+/// 二维码用系统 CoreImage 生成，无需第三方库。
+struct MyDIDView: View {
+    @Environment(\.dismiss) private var dismiss
+    let did: String
+    @State private var copied = false
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                Spacer()
+
+                if let img = Self.qrImage(from: did) {
+                    Image(uiImage: img)
+                        .interpolation(.none)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 240, height: 240)
+                        .padding()
+                        .background(Color.white)
+                        .cornerRadius(16)
+                        .shadow(radius: 4)
+                } else {
+                    Image(systemName: "qrcode")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 200, height: 200)
+                        .foregroundColor(.gray)
+                }
+
+                Text("我的 DID")
+                    .font(.headline)
+
+                Text(did.isEmpty ? "尚未生成 DID" : did)
+                    .font(.system(.footnote, design: .monospaced))
+                    .multilineTextAlignment(.center)
+                    .textSelection(.enabled)
+                    .padding(.horizontal)
+
+                Button {
+                    UIPasteboard.general.string = did
+                    copied = true
+                } label: {
+                    Label(copied ? "已复制" : "复制 DID", systemImage: copied ? "checkmark" : "doc.on.doc")
+                }
+                .disabled(did.isEmpty)
+
+                Text("让好友扫描或输入你的 DID 即可添加你为好友。")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                    .padding()
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("我的二维码")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("完成") { dismiss() }
+                }
+            }
+        }
+    }
+
+    static func qrImage(from string: String) -> UIImage? {
+        guard !string.isEmpty else { return nil }
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        filter.correctionLevel = "M"
+        guard let output = filter.outputImage else { return nil }
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Views/PostDetailView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/PostDetailView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// 动态详情 + 评论（与 Android `PostDetailScreen` 对齐）
+struct PostDetailView: View {
+    @StateObject private var viewModel: PostDetailViewModel
+    @State private var newComment = ""
+    @FocusState private var commentFocused: Bool
+
+    init(post: SocialPost) {
+        _viewModel = StateObject(wrappedValue: PostDetailViewModel(post: post))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    PostRow(post: viewModel.post, onLike: {})
+                        .padding(.horizontal)
+
+                    Divider()
+
+                    Text("评论 (\(viewModel.comments.count))")
+                        .font(.headline)
+                        .padding(.horizontal)
+
+                    if viewModel.isLoading && viewModel.comments.isEmpty {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.top, 24)
+                    } else if viewModel.comments.isEmpty {
+                        Text("还没有评论，来抢沙发吧")
+                            .font(.subheadline)
+                            .foregroundColor(.gray)
+                            .frame(maxWidth: .infinity)
+                            .padding(.top, 24)
+                    } else {
+                        ForEach(viewModel.comments) { comment in
+                            CommentRow(comment: comment)
+                                .padding(.horizontal)
+                                .swipeActions(edge: .trailing) {
+                                    if viewModel.canDelete(comment) {
+                                        Button(role: .destructive) {
+                                            viewModel.deleteComment(comment)
+                                        } label: {
+                                            Label("删除", systemImage: "trash")
+                                        }
+                                    }
+                                }
+                        }
+                    }
+                }
+                .padding(.vertical)
+            }
+
+            Divider()
+
+            HStack(spacing: 8) {
+                TextField("写评论…", text: $newComment)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($commentFocused)
+
+                Button(action: submitComment) {
+                    Image(systemName: "paperplane.fill")
+                        .foregroundColor(canSend ? .blue : .gray)
+                }
+                .disabled(!canSend)
+            }
+            .padding()
+        }
+        .navigationTitle("动态详情")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.load()
+        }
+    }
+
+    private var canSend: Bool {
+        !newComment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func submitComment() {
+        let text = newComment
+        newComment = ""
+        commentFocused = false
+        Task { await viewModel.addComment(text) }
+    }
+}
+
+// MARK: - Comment Row
+
+struct CommentRow: View {
+    let comment: SocialComment
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(comment.displayAuthor)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                Text(comment.createdAt, style: .relative)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+            }
+            Text(comment.content)
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Views/PublishPostView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/PublishPostView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// 发布动态（与 Android `PublishPostScreen` 对齐）
+struct PublishPostView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var content = ""
+    @State private var visibility: PostVisibility = .publicAll
+
+    /// (内容, 可见性)
+    let onPublish: (String, PostVisibility) -> Void
+
+    private var canPublish: Bool {
+        !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 16) {
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $content)
+                        .frame(minHeight: 160)
+
+                    if content.isEmpty {
+                        Text("分享你的想法…")
+                            .foregroundColor(.gray)
+                            .padding(.top, 8)
+                            .padding(.leading, 5)
+                            .allowsHitTesting(false)
+                    }
+                }
+
+                Picker("可见性", selection: $visibility) {
+                    ForEach(PostVisibility.allCases) { vis in
+                        Text(vis.displayName).tag(vis)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                HStack(spacing: 6) {
+                    Image(systemName: visibility.systemImage)
+                    Text(visibilityHint)
+                }
+                .font(.caption)
+                .foregroundColor(.gray)
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("发布动态")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("发布") {
+                        onPublish(content, visibility)
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(!canPublish)
+                }
+            }
+        }
+    }
+
+    private var visibilityHint: String {
+        switch visibility {
+        case .publicAll: return "所有人都能看到这条动态"
+        case .friends: return "只有你的好友能看到"
+        case .privateOnly: return "只有你自己能看到"
+        }
+    }
+}

--- a/ios-app/ChainlessChain/Features/Social/Views/SocialFeedView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/SocialFeedView.swift
@@ -1,34 +1,152 @@
 import SwiftUI
+import CoreCommon
 
+/// 去中心化社交「广场」时间线（与 Android `TimelineScreen` 对齐）
 struct SocialFeedView: View {
+    @StateObject private var viewModel = SocialFeedViewModel()
+    @State private var showPublish = false
+
     var body: some View {
         NavigationView {
-            ScrollView {
-                VStack(spacing: 20) {
-                    Image(systemName: "person.3.fill")
-                        .resizable()
-                        .frame(width: 80, height: 60)
-                        .foregroundColor(.gray)
-
-                    Text("社交功能")
-                        .font(.title)
-                        .fontWeight(.bold)
-
-                    Text("去中心化社交网络")
-                        .font(.subheadline)
-                        .foregroundColor(.gray)
-
-                    Text("即将推出")
-                        .font(.headline)
-                        .foregroundColor(.blue)
-                        .padding()
-                        .background(Color.blue.opacity(0.1))
-                        .cornerRadius(12)
+            ZStack {
+                if viewModel.isLoading && viewModel.posts.isEmpty {
+                    ProgressView("加载中...")
+                } else if viewModel.posts.isEmpty {
+                    emptyView
+                } else {
+                    listView
                 }
-                .padding()
             }
-            .navigationTitle("社交")
+            .navigationTitle("社交广场")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showPublish = true }) {
+                        Image(systemName: "square.and.pencil")
+                    }
+                }
+            }
+            .sheet(isPresented: $showPublish) {
+                PublishPostView { content, visibility in
+                    Task { await viewModel.publish(content: content, visibility: visibility) }
+                }
+            }
+            .refreshable {
+                await viewModel.refresh()
+            }
         }
+        .task {
+            await viewModel.loadFeed()
+        }
+    }
+
+    private var listView: some View {
+        List {
+            ForEach(viewModel.posts) { post in
+                ZStack {
+                    PostRow(post: post, onLike: { viewModel.toggleLike(post) })
+                    NavigationLink(destination: PostDetailView(post: post)) {
+                        EmptyView()
+                    }
+                    .opacity(0)
+                }
+                .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                .swipeActions(edge: .trailing) {
+                    if viewModel.canDelete(post) {
+                        Button(role: .destructive) {
+                            viewModel.deletePost(post)
+                        } label: {
+                            Label("删除", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "person.3.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 80, height: 60)
+                .foregroundColor(.gray)
+
+            Text("还没有动态")
+                .font(.headline)
+                .foregroundColor(.gray)
+
+            Text("发布第一条去中心化动态，与好友分享")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+
+            Button(action: { showPublish = true }) {
+                Label("发布动态", systemImage: "square.and.pencil")
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Post Row
+
+struct PostRow: View {
+    let post: SocialPost
+    let onLike: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(Color.blue.opacity(0.7))
+                        .frame(width: 40, height: 40)
+                    Text(post.displayAuthor.suffix(1).uppercased())
+                        .font(.headline)
+                        .foregroundColor(.white)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(post.displayAuthor)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Text(post.createdAt, style: .relative)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+
+                Spacer()
+
+                Image(systemName: post.visibility.systemImage)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+            }
+
+            Text(post.content)
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 24) {
+                Button(action: onLike) {
+                    Label("\(post.likeCount)", systemImage: post.isLiked ? "heart.fill" : "heart")
+                        .foregroundColor(post.isLiked ? .red : .gray)
+                }
+                .buttonStyle(.borderless)
+
+                Label("\(post.commentCount)", systemImage: "bubble.right")
+                    .foregroundColor(.gray)
+
+                Spacer()
+            }
+            .font(.subheadline)
+        }
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
     }
 }
 

--- a/ios-app/ChainlessChain/Features/Social/Views/UserPostsView.swift
+++ b/ios-app/ChainlessChain/Features/Social/Views/UserPostsView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import CoreCommon
+
+/// 查看某位好友的动态（复用社交广场的帖子模型）
+struct UserPostsView: View {
+    let authorDID: String
+    let title: String
+    @StateObject private var model: UserPostsModel
+
+    init(authorDID: String, title: String) {
+        self.authorDID = authorDID
+        self.title = title
+        _model = StateObject(wrappedValue: UserPostsModel(authorDID: authorDID))
+    }
+
+    var body: some View {
+        ZStack {
+            if model.isLoading && model.posts.isEmpty {
+                ProgressView()
+            } else if model.posts.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "doc.text.magnifyingglass")
+                        .font(.largeTitle)
+                        .foregroundColor(.gray)
+                    Text("TA 还没有发布动态")
+                        .foregroundColor(.gray)
+                }
+            } else {
+                List {
+                    ForEach(model.posts) { post in
+                        ZStack {
+                            PostRow(post: post, onLike: {})
+                            NavigationLink(destination: PostDetailView(post: post)) {
+                                EmptyView()
+                            }
+                            .opacity(0)
+                        }
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await model.load()
+        }
+    }
+}
+
+@MainActor
+final class UserPostsModel: ObservableObject {
+    @Published var posts: [SocialPost] = []
+    @Published var isLoading = false
+
+    let authorDID: String
+    private let repository = SocialRepository.shared
+
+    private var currentDID: String { AppState.shared.currentDID ?? "" }
+
+    init(authorDID: String) {
+        self.authorDID = authorDID
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            posts = try repository.getUserPosts(authorDID: authorDID, currentDID: currentDID)
+        } catch {
+            posts = []
+        }
+    }
+}

--- a/ios-app/Modules/CoreCommon/Sources/CoreCommon/Constants/AppConstants.swift
+++ b/ios-app/Modules/CoreCommon/Sources/CoreCommon/Constants/AppConstants.swift
@@ -35,7 +35,7 @@ public enum AppConstants {
     /// 数据库配置
     public enum Database {
         public static let name = "chainlesschain.db"
-        public static let version = 2
+        public static let version = 3
         public static let encryptionKeySize = 32 // 256 bits
         public static let pbkdf2Iterations = 256_000
     }

--- a/ios-app/Modules/CoreDatabase/Sources/CoreDatabase/Manager/DatabaseManager.swift
+++ b/ios-app/Modules/CoreDatabase/Sources/CoreDatabase/Manager/DatabaseManager.swift
@@ -203,29 +203,35 @@ public class DatabaseManager {
     /// 执行 SQL 语句
     @discardableResult
     public func execute(_ sql: String) throws -> Int {
-        return try queue.sync {
-            guard let database = db else {
-                throw DatabaseError.notOpen
-            }
+        return try queue.sync { try _execute(sql) }
+    }
 
-            var errorMessage: UnsafeMutablePointer<CChar>?
-            let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
-
-            if result != SQLITE_OK {
-                let message: String
-                if let errorPtr = errorMessage {
-                    message = String(cString: errorPtr)
-                    sqlite3_free(errorPtr)
-                } else {
-                    message = "Unknown error"
-                }
-                logger.database("SQL execution failed: \(message)", level: .error)
-                throw DatabaseError.executionFailed(message)
-            }
-
-            let changes = Int(sqlite3_changes(database))
-            return changes
+    /// 内部执行（**不**获取 `queue` 锁）。仅供已经运行在 `queue` 闭包内的代码
+    /// 调用（如 `open` → `runMigrations`）。对串行队列重入 `queue.sync` 会让
+    /// 线程永久死锁——这正是首次输入 PIN 打开数据库时「闪退」(watchdog 杀进程)
+    /// 的根因。所有 `open()` 同步上下文里的 SQL 必须走这些 `_` 前缀的原语。
+    @discardableResult
+    private func _execute(_ sql: String) throws -> Int {
+        guard let database = db else {
+            throw DatabaseError.notOpen
         }
+
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
+
+        if result != SQLITE_OK {
+            let message: String
+            if let errorPtr = errorMessage {
+                message = String(cString: errorPtr)
+                sqlite3_free(errorPtr)
+            } else {
+                message = "Unknown error"
+            }
+            logger.database("SQL execution failed: \(message)", level: .error)
+            throw DatabaseError.executionFailed(message)
+        }
+
+        return Int(sqlite3_changes(database))
     }
 
     /// 执行带参数绑定的 SQL（INSERT/UPDATE/DELETE 用）。`execute(_:)` 走的是
@@ -265,39 +271,49 @@ public class DatabaseManager {
 
     /// 执行查询
     public func query<T>(_ sql: String, parameters: [Any?] = [], mapper: (OpaquePointer) -> T?) throws -> [T] {
-        return try queue.sync {
-            guard let database = db else {
-                throw DatabaseError.notOpen
-            }
+        return try queue.sync { try _query(sql, parameters: parameters, mapper: mapper) }
+    }
 
-            var statement: OpaquePointer?
-            let prepareResult = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
-
-            guard prepareResult == SQLITE_OK, let stmt = statement else {
-                let errorMessage = String(cString: sqlite3_errmsg(database))
-                throw DatabaseError.queryFailed(errorMessage)
-            }
-
-            defer { sqlite3_finalize(stmt) }
-
-            // 绑定参数
-            try bindParameters(stmt, parameters: parameters)
-
-            var results: [T] = []
-
-            while sqlite3_step(stmt) == SQLITE_ROW {
-                if let item = mapper(stmt) {
-                    results.append(item)
-                }
-            }
-
-            return results
+    /// 内部查询（**不**获取 `queue` 锁）。见 `_execute` 的注释——`open()` 同步
+    /// 上下文里的查询（如 `getCurrentVersion`）必须走这里，否则串行队列重入死锁。
+    private func _query<T>(_ sql: String, parameters: [Any?] = [], mapper: (OpaquePointer) -> T?) throws -> [T] {
+        guard let database = db else {
+            throw DatabaseError.notOpen
         }
+
+        var statement: OpaquePointer?
+        let prepareResult = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
+
+        guard prepareResult == SQLITE_OK, let stmt = statement else {
+            let errorMessage = String(cString: sqlite3_errmsg(database))
+            throw DatabaseError.queryFailed(errorMessage)
+        }
+
+        defer { sqlite3_finalize(stmt) }
+
+        // 绑定参数
+        try bindParameters(stmt, parameters: parameters)
+
+        var results: [T] = []
+
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let item = mapper(stmt) {
+                results.append(item)
+            }
+        }
+
+        return results
     }
 
     /// 执行单行查询
     public func queryOne<T>(_ sql: String, parameters: [Any?] = [], mapper: (OpaquePointer) -> T?) throws -> T? {
         let results: [T] = try query(sql, parameters: parameters, mapper: mapper)
+        return results.first
+    }
+
+    /// 内部单行查询（**不**获取 `queue` 锁），供 `open()` 同步上下文使用。
+    private func _queryOne<T>(_ sql: String, parameters: [Any?] = [], mapper: (OpaquePointer) -> T?) throws -> T? {
+        let results: [T] = try _query(sql, parameters: parameters, mapper: mapper)
         return results.first
     }
 
@@ -368,9 +384,14 @@ public class DatabaseManager {
     // MARK: - Migration
 
     /// 运行数据库迁移
+    ///
+    /// **重要**：本方法及其调用链（`getCurrentVersion` / `runMigration` /
+    /// `migration_v1`）只在 `open()` 的 `queue.sync` 闭包内被调用，因此一律使用
+    /// `_execute` / `_queryOne` 这些**不**重入队列的内部原语。改用公开的
+    /// `execute` / `queryOne` 会对串行队列重入 `sync` → 死锁（首次输入 PIN 闪退）。
     private func runMigrations() throws {
         // 创建 migrations 表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS migrations (
                 version INTEGER PRIMARY KEY,
                 applied_at INTEGER NOT NULL
@@ -389,9 +410,9 @@ public class DatabaseManager {
         }
     }
 
-    /// 获取当前数据库版本
+    /// 获取当前数据库版本（在 `open()` 同步上下文内调用，走非重入的 `_queryOne`）
     private func getCurrentVersion() throws -> Int {
-        let result: Int? = try queryOne("SELECT MAX(version) FROM migrations;") { stmt in
+        let result: Int? = try _queryOne("SELECT MAX(version) FROM migrations;") { stmt in
             return Int(sqlite3_column_int(stmt, 0))
         }
         return result ?? 0
@@ -408,19 +429,21 @@ public class DatabaseManager {
         // BlockchainMigration.swift which is currently excluded from compile
         // (Package.swift exclude: [...]). Re-enable when Migrations folder
         // dependencies are implemented.
+        case 3:
+            try migration_v3()
         default:
             break
         }
 
-        // 记录迁移
-        try execute("INSERT INTO migrations (version, applied_at) VALUES (\(version), \(Date().timestampMs));")
+        // 记录迁移（同步上下文内，走非重入的 `_execute`）
+        try _execute("INSERT INTO migrations (version, applied_at) VALUES (\(version), \(Date().timestampMs));")
         logger.database("Migration v\(version) completed")
     }
 
     /// 迁移 v1: 创建核心表
     private func migration_v1() throws {
         // 用户设置表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS settings (
                 key TEXT PRIMARY KEY,
                 value TEXT NOT NULL,
@@ -429,7 +452,7 @@ public class DatabaseManager {
         """)
 
         // DID 身份表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS did_identities (
                 id TEXT PRIMARY KEY,
                 did TEXT NOT NULL UNIQUE,
@@ -444,7 +467,7 @@ public class DatabaseManager {
         """)
 
         // 联系人表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS contacts (
                 id TEXT PRIMARY KEY,
                 did TEXT NOT NULL UNIQUE,
@@ -459,7 +482,7 @@ public class DatabaseManager {
         """)
 
         // 对话表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS conversations (
                 id TEXT PRIMARY KEY,
                 type TEXT NOT NULL DEFAULT 'direct',
@@ -476,7 +499,7 @@ public class DatabaseManager {
         """)
 
         // 消息表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS messages (
                 id TEXT PRIMARY KEY,
                 conversation_id TEXT NOT NULL,
@@ -493,7 +516,7 @@ public class DatabaseManager {
         """)
 
         // 知识库表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS knowledge_items (
                 id TEXT PRIMARY KEY,
                 title TEXT NOT NULL,
@@ -511,7 +534,7 @@ public class DatabaseManager {
         """)
 
         // AI 对话表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS ai_conversations (
                 id TEXT PRIMARY KEY,
                 title TEXT,
@@ -526,7 +549,7 @@ public class DatabaseManager {
         """)
 
         // AI 消息表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS ai_messages (
                 id TEXT PRIMARY KEY,
                 conversation_id TEXT NOT NULL,
@@ -539,7 +562,7 @@ public class DatabaseManager {
         """)
 
         // 社交帖子表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS social_posts (
                 id TEXT PRIMARY KEY,
                 author_did TEXT NOT NULL,
@@ -556,7 +579,7 @@ public class DatabaseManager {
         """)
 
         // 数字资产表
-        try execute("""
+        try _execute("""
             CREATE TABLE IF NOT EXISTS assets (
                 id TEXT PRIMARY KEY,
                 name TEXT NOT NULL,
@@ -572,13 +595,47 @@ public class DatabaseManager {
         """)
 
         // 创建索引
-        try execute("CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id);")
-        try execute("CREATE INDEX IF NOT EXISTS idx_messages_created ON messages(created_at);")
-        try execute("CREATE INDEX IF NOT EXISTS idx_knowledge_created ON knowledge_items(created_at);")
-        try execute("CREATE INDEX IF NOT EXISTS idx_ai_messages_conversation ON ai_messages(conversation_id);")
-        try execute("CREATE INDEX IF NOT EXISTS idx_contacts_did ON contacts(did);")
+        try _execute("CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id);")
+        try _execute("CREATE INDEX IF NOT EXISTS idx_messages_created ON messages(created_at);")
+        try _execute("CREATE INDEX IF NOT EXISTS idx_knowledge_created ON knowledge_items(created_at);")
+        try _execute("CREATE INDEX IF NOT EXISTS idx_ai_messages_conversation ON ai_messages(conversation_id);")
+        try _execute("CREATE INDEX IF NOT EXISTS idx_contacts_did ON contacts(did);")
 
         logger.database("Created v1 schema with core tables")
+    }
+
+    /// 迁移 v3: 去中心化社交网络（动态/评论/点赞）。
+    /// `social_posts` 表已在 v1 创建，这里补齐评论与点赞明细表，使 iOS 端的
+    /// 社交「广场」与 Android 端对齐（帖子 / 评论 / 点赞 / 时间线）。
+    private func migration_v3() throws {
+        // 帖子评论表（支持二级回复：parent_comment_id）
+        try _execute("""
+            CREATE TABLE IF NOT EXISTS social_post_comments (
+                id TEXT PRIMARY KEY,
+                post_id TEXT NOT NULL,
+                author_did TEXT NOT NULL,
+                content TEXT NOT NULL,
+                parent_comment_id TEXT,
+                created_at INTEGER NOT NULL,
+                FOREIGN KEY (post_id) REFERENCES social_posts(id)
+            );
+        """)
+
+        // 帖子点赞明细表（记录谁点了赞，便于撤销与去重）
+        try _execute("""
+            CREATE TABLE IF NOT EXISTS social_post_likes (
+                post_id TEXT NOT NULL,
+                liker_did TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                PRIMARY KEY (post_id, liker_did)
+            );
+        """)
+
+        try _execute("CREATE INDEX IF NOT EXISTS idx_social_posts_created ON social_posts(created_at DESC);")
+        try _execute("CREATE INDEX IF NOT EXISTS idx_social_comments_post ON social_post_comments(post_id);")
+        try _execute("CREATE INDEX IF NOT EXISTS idx_social_likes_post ON social_post_likes(post_id);")
+
+        logger.database("Created v3 social network schema (posts/comments/likes)")
     }
 
     // MARK: - Maintenance


### PR DESCRIPTION
**隔离版** PR（替代 #38）——只含 1 个 ios-app/ 提交，无任何并行 session 的 cli/desktop 改动。

## ① PIN 闪退修复
`CoreDatabase/DatabaseManager.open()` 串行 `queue.sync` 内部又调用公开 `execute()/queryOne()`（各自再 `queue.sync`）→ 同串行队列重入死锁 → 主线程挂 → watchdog 杀进程（用户看到闪退）。首次 PIN setup/login 必触发。修：加非重入内部原语 `_execute/_query/_queryOne`。

## ② 去中心化社交对齐
- 动态广场（帖/评/赞，DB migration v3）
- 好友系统（复用 P2PContactRepository，补 UI：好友列表/按 DID 添加/资料/屏蔽/我的二维码/查看好友动态）
- 入口：「消息」tab 左上角 Menu

## 验证
iOS CI 已在前序分支全绿（Build & Test SPM / SwiftLint / Security / Build Release SPM 4/4 ✅）。app-target 全量类型检查需 Mac/Xcode。

🤖 Generated with [Claude Code](https://claude.com/claude-code)