### PR TITLE
fix(desktop): bridge-security — resilient auto-resume (no unhandled rejection)

### DIFF
--- a/desktop-app-vue/src/main/blockchain/__tests__/bridge-security-resume.test.js
+++ b/desktop-app-vue/src/main/blockchain/__tests__/bridge-security-resume.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const BridgeSecurityManager = require("../bridge-security.js");
+
+describe("BridgeSecurityManager auto-resume resilience", () => {
+  let mgr;
+
+  beforeEach(() => {
+    mgr = new BridgeSecurityManager({}); // db unused once logSecurityEvent is stubbed
+  });
+
+  it("resumeBridge resumes and emits on a successful audit write", async () => {
+    vi.spyOn(mgr, "logSecurityEvent").mockResolvedValue();
+    mgr.isPaused = true;
+    const onResumed = vi.fn();
+    mgr.on("bridge-resumed", onResumed);
+
+    await expect(mgr.resumeBridge()).resolves.toBeUndefined();
+
+    expect(mgr.isPaused).toBe(false);
+    expect(mgr.pausedUntil).toBeNull();
+    expect(onResumed).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumeBridge still resumes when the audit-log write fails (no unhandled rejection)", async () => {
+    // Regression: previously a rejected logSecurityEvent made resumeBridge
+    // reject (unhandled, since it's invoked from an unawaited timer) and the
+    // bridge-resumed event was never emitted.
+    vi.spyOn(mgr, "logSecurityEvent").mockRejectedValue(new Error("db down"));
+    mgr.isPaused = true;
+    const onResumed = vi.fn();
+    mgr.on("bridge-resumed", onResumed);
+
+    await expect(mgr.resumeBridge()).resolves.toBeUndefined(); // does NOT reject
+    expect(mgr.isPaused).toBe(false); // bridge still resumed
+    expect(onResumed).toHaveBeenCalledTimes(1); // event still emitted
+  });
+
+  it("pauseBridge schedules an auto-resume timer that resumeBridge cancels", async () => {
+    vi.spyOn(mgr, "logSecurityEvent").mockResolvedValue();
+
+    await mgr.pauseBridge(60_000, "test");
+    expect(mgr.isPaused).toBe(true);
+    expect(mgr.autoResumeTimer).toBeTruthy(); // timer scheduled
+
+    await mgr.resumeBridge();
+    expect(mgr.autoResumeTimer).toBeNull(); // cancelled on resume
+  });
+});

--- a/desktop-app-vue/src/main/blockchain/bridge-security.js
+++ b/desktop-app-vue/src/main/blockchain/bridge-security.js
@@ -506,10 +506,16 @@ class BridgeSecurityManager extends EventEmitter {
       `[BridgeSecurity] Bridge paused until ${new Date(this.pausedUntil).toISOString()}`,
     );
 
-    // Auto-resume after duration
-    setTimeout(() => {
+    // Auto-resume after duration. unref so the background timer never keeps the
+    // process alive, and store the handle so a manual resume / shutdown can
+    // cancel it. resumeBridge() is now resilient, so the unawaited call can't
+    // surface an unhandled rejection.
+    this.autoResumeTimer = setTimeout(() => {
       this.resumeBridge();
     }, duration);
+    if (this.autoResumeTimer && this.autoResumeTimer.unref) {
+      this.autoResumeTimer.unref();
+    }
   }
 
   /**
@@ -518,12 +524,26 @@ class BridgeSecurityManager extends EventEmitter {
   async resumeBridge() {
     this.isPaused = false;
     this.pausedUntil = null;
+    if (this.autoResumeTimer) {
+      clearTimeout(this.autoResumeTimer);
+      this.autoResumeTimer = null;
+    }
 
-    await this.logSecurityEvent({
-      type: "BRIDGE_RESUMED",
-      severity: "info",
-      details: "Bridge operations resumed",
-    });
+    // Best-effort audit log: a failed write must not prevent the resume nor
+    // surface as an unhandled rejection (resumeBridge is invoked from an
+    // unawaited auto-resume timer).
+    try {
+      await this.logSecurityEvent({
+        type: "BRIDGE_RESUMED",
+        severity: "info",
+        details: "Bridge operations resumed",
+      });
+    } catch (err) {
+      logger.error(
+        "[BridgeSecurity] Failed to log BRIDGE_RESUMED audit event:",
+        err,
+      );
+    }
 
     this.emit("bridge-resumed");
 


### PR DESCRIPTION
Bridge auto-resume runs from an unawaited `setTimeout` calling async `resumeBridge()`. If the `BRIDGE_RESUMED` audit-log write rejected, `resumeBridge()` rejected — an **unhandled promise rejection**, and the `bridge-resumed` emit was skipped (the `await` threw first).

Fix: best-effort audit write (try/catch + error log) so the bridge always resumes and the call never rejects; also `unref`/store/clear the auto-resume timer (no process-keep-alive / leak; resume cancels a pending auto-resume). + 3-test resume suite incl. the audit-failure regression. Used by bridge-manager.

Conflict-free. Admin-merged for speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)